### PR TITLE
examples: add codebase agent workspace

### DIFF
--- a/examples/codebase/README.md
+++ b/examples/codebase/README.md
@@ -1,0 +1,185 @@
+# Codebase Agent Workspace
+
+Multi-agent code collaboration graph. Models the "database as a git" paradigm where files are structured nodes, agents work on branches, and import relationships are first-class edges.
+
+**Thesis:** Code is high-velocity data. Agent tool calls (read, write, grep) should be graph operations, not filesystem I/O. Conflict detection, blast radius analysis, and review routing become graph traversals.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `codebase.pg` | Schema with mutable pointer nodes, append-only event nodes, and agent-facing metadata |
+| `codebase.gq` | Query suite: file ops, search (keyword/semantic/hybrid), import graph, conflict detection, review routing, aggregation, negation, filtering, mutations |
+| `codebase.jsonl` | Seed data: "Acme API" project with 3 agents, 15 files, 4 concurrent tasks |
+
+## Quick Start
+
+```bash
+cd codebase
+
+nanograph init
+nanograph load --data codebase.jsonl --mode overwrite
+nanograph embed
+nanograph check --query codebase.gq
+nanograph run active
+nanograph run blast src/auth/jwt.ts
+nanograph run conflicts task-usage-alerts
+nanograph run why "token revocation"
+nanograph run why "token revocation" --format kv
+```
+
+The checked-in `nanograph.toml` provides:
+
+- `db.default_path = "codebase.nano"`
+- `query.roots = ["."]`
+- aliases like `read`, `find`, `search`, `blast`, `conflicts`, `reviewers`, `why`, `hotspots`
+- deterministic mock embeddings for description and reasoning fields
+
+`nanograph run` supports `table` (default), `kv`, `csv`, `jsonl`, and `json`.
+- `kv` is the record-oriented human view
+- `json` wraps result rows with query metadata plus `rows`
+
+See also:
+
+- [Search Guide](../../docs/user/search.md)
+- [Project Config](../../docs/user/config.md)
+
+## Schema Overview
+
+### Pointer Nodes (Mutable)
+
+Updated in place. All carry `slug @key`, `createdAt`, `updatedAt`.
+
+- **Module** — logical grouping of files (package, directory)
+- **File** — source file with full content, path, language, description
+- **Agent** — human or AI, with model and capabilities
+- **Task** — unit of work mapping 1:1 to a nanograph branch
+- **Constraint** — rule that must pass before merge (lint, typecheck, test, security)
+
+### Append-Only Nodes (Immutable)
+
+Never overwritten. All carry `slug @key`, `createdAt` (no `updatedAt`).
+
+- **Decision** — why something was designed or changed a certain way
+- **Review** — verdict on a task branch (approved, changes_requested, blocked)
+
+### Edge Types (11)
+
+**Structure:** Contains (Module→File), Imports (File→File)
+
+**Work:** Assigned (Agent→Task), Modifies (Task→File), Expert (Agent→Module), Governs (Constraint→File)
+
+**Collaboration:** Decides (Decision→File), MadeBy (Decision→Agent), Reviews (Review→Task), ReviewedBy (Review→Agent), References (Task→Task)
+
+## Query Catalog
+
+### File Operations
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `read_file` | `$path` | Read a file by path |
+| `list_files` | `$mod` | List all files in a module |
+| `keyword_search_files` | `$q` | Find files by keyword in descriptions |
+| `semantic_search_files` | `$q` | Rank files by semantic similarity |
+| `hybrid_search_files` | `$q` | Blend semantic and lexical ranking |
+| `search_modules` | `$q` | Semantic search across modules |
+
+### Import Graph
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `file_dependencies` | `$path` | What does this file import? |
+| `file_dependents` | `$path` | What files import this file? (blast radius) |
+| `import_chain` | `$path` | Two-hop transitive dependents |
+
+### Task & Agent Management
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `agent_tasks` | `$agent` | Tasks assigned to an agent |
+| `task_files` | `$task` | Files modified by a task |
+| `task_detail` | `$task` | Full task view: agent, files, branch |
+| `active_work` | — | All in-progress tasks with agents |
+| `open_tasks` | — | Tasks not yet started |
+| `search_tasks` | `$q` | Semantic search across task descriptions |
+
+### Conflict Detection
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `file_conflicts` | `$task` | Other tasks modifying the same files |
+| `import_conflicts` | `$task` | Tasks modifying dependencies of your files |
+
+### Review Routing
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `review_candidates` | `$task` | Experts in modules this task touches |
+| `task_constraints` | `$task` | Constraints that must pass before merge |
+| `task_reviews` | `$task` | Review history on a task |
+
+### Decisions
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `search_decisions` | `$q` | Semantic search across past decisions |
+| `keyword_search_decisions` | `$q` | Keyword search in decision reasoning |
+| `file_decisions` | `$path` | Decisions affecting a specific file |
+| `decision_trace` | `$task` | Decisions linked to files a task modifies |
+
+### Agent Expertise
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `module_experts` | `$mod` | Who knows this module? |
+| `agent_expertise` | `$agent` | What modules does this agent know? |
+
+### Aggregation
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `files_per_module` | — | File count per module |
+| `tasks_per_agent` | — | Task count per agent |
+| `most_imported` | — | Files ranked by import count |
+| `most_constrained` | — | Files ranked by constraint count |
+
+### Negation
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `ungoverned_files` | — | Files with no constraints |
+| `unassigned_tasks` | — | Tasks with no agent assigned |
+| `orphan_files` | — | Files not in any module |
+
+### Filtering
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `recent_tasks` | `$since` | Tasks created after a date |
+| `recent_decisions` | `$since` | Decisions made after a date |
+| `error_constraints` | — | Constraints with severity = error |
+
+### Mutations
+| Query | Parameters | Description |
+|-------|-----------|-------------|
+| `write_file` | `$slug, $path, ...` | Insert a new file |
+| `update_file_content` | `$path, $content, ...` | Update file content |
+| `delete_file` | `$path` | Delete a file |
+| `create_task` | `$slug, $title, ...` | Create a new task |
+| `start_task` | `$slug` | Move task to in_progress |
+| `submit_for_review` | `$slug` | Move task to in_review |
+| `merge_task` | `$slug` | Move task to merged |
+| `add_decision` | `$slug, ...` | Record a new decision |
+| `add_review` | `$slug, ...` | Add a review verdict |
+
+## Seed Data: Acme API
+
+The seed data models a TypeScript API project with three agents working concurrently:
+
+1. **Claude** (AI) — working on refresh token rotation (`feat/refresh-tokens`), modifying auth middleware and JWT module
+2. **Devin** (AI) — building usage threshold alerts (`feat/usage-alerts`), modifying billing meter and API routes
+3. **Sarah** (human) — reviewed the Redis rate limiter migration, expert on auth and core modules
+
+**The interesting conflict:** Claude's refresh token task and Devin's usage alerts task both modify files that interact through the import graph. The `file_conflicts` query surfaces direct overlaps. The `import_conflicts` query finds subtler dependency-level conflicts.
+
+**The review routing:** When checking reviewers for Claude's refresh token task, the graph traverses Modifies→File→Contains→Module→Expert and finds Sarah (expert on auth module with high confidence).
+
+**The decision memory:** The rate limiter was explicitly designed as a temporary in-memory solution. Searching decisions for "rate limiter temporary" surfaces the original reasoning, giving the agent context before starting the Redis migration.
+
+## Adding Data
+
+```bash
+nanograph load --data your-data.jsonl --mode merge
+```
+
+To evolve the schema, edit `codebase.nano/schema.pg` then run `nanograph migrate`.

--- a/examples/codebase/codebase.gq
+++ b/examples/codebase/codebase.gq
@@ -1,0 +1,561 @@
+// Codebase Agent Workspace — NanoGraph Queries
+// Demonstrates: file lookup, import traversal, blast radius,
+//               conflict detection, review routing, semantic search,
+//               hybrid search, aggregation, negation, date filtering,
+//               decision traces, task management, mutations
+
+// ═══════════════════════════════════════════════════════════════
+// FILE OPERATIONS — What agents call instead of filesystem I/O
+// ═══════════════════════════════════════════════════════════════
+
+query read_file($path: String)
+  @description("Read a file by path. Equivalent to agent 'read' tool call.")
+{
+    match { $f: File { path: $path } }
+    return { $f.slug, $f.path, $f.language, $f.content, $f.hash }
+}
+
+query list_files($mod: String)
+  @description("List all files in a module.")
+{
+    match {
+        $m: Module { slug: $mod }
+        $m contains $f
+    }
+    return { $f.slug, $f.path, $f.language, $f.size }
+    order { $f.path }
+}
+
+// ── Search: keyword, semantic, hybrid ───────────────────────────
+
+query keyword_search_files($q: String)
+  @description("Find files whose descriptions contain the query tokens.")
+  @instruction("Use for exact term lookup across file descriptions.")
+{
+    match {
+        $f: File
+        search($f.description, $q)
+    }
+    return { $f.slug, $f.path, $f.language }
+    order { $f.path }
+}
+
+query semantic_search_files($q: String)
+  @description("Rank files by semantic similarity against their descriptions.")
+  @instruction("Use for broad conceptual search: 'where is the auth code?' or 'find the rate limiter'.")
+{
+    match { $f: File }
+    return { $f.slug, $f.path, $f.language, $f.description, nearest($f.descriptionEmbedding, $q) as score }
+    order { nearest($f.descriptionEmbedding, $q) }
+    limit 10
+}
+
+query hybrid_search_files($q: String)
+  @description("Blend semantic and lexical ranking across file descriptions.")
+  @instruction("Use when both exact wording and broader meaning matter.")
+{
+    match { $f: File }
+    return {
+        $f.slug
+        $f.path
+        $f.language
+        nearest($f.descriptionEmbedding, $q) as semantic_distance
+        bm25($f.description, $q) as lexical_score
+        rrf(nearest($f.descriptionEmbedding, $q), bm25($f.description, $q)) as hybrid_score
+    }
+    order { rrf(nearest($f.descriptionEmbedding, $q), bm25($f.description, $q)) desc }
+    limit 10
+}
+
+query search_modules($q: String)
+  @description("Semantic search across module descriptions.")
+{
+    match { $m: Module }
+    return { $m.slug, $m.name, $m.path, $m.description, nearest($m.descriptionEmbedding, $q) as score }
+    order { nearest($m.descriptionEmbedding, $q) }
+    limit 5
+}
+
+// ═══════════════════════════════════════════════════════════════
+// IMPORT GRAPH — Blast radius and dependency analysis
+// ═══════════════════════════════════════════════════════════════
+
+query file_dependencies($path: String)
+  @description("What does this file import?")
+{
+    match {
+        $f: File { path: $path }
+        $f imports $dep
+    }
+    return { $f.path as file, $dep.path as imports, $dep.language }
+}
+
+query file_dependents($path: String)
+  @description("What files import this file? The blast radius of a change.")
+  @instruction("Run this before modifying any file to understand impact.")
+{
+    match {
+        $f: File { path: $path }
+        $dependent imports $f
+    }
+    return { $f.path as file, $dependent.path as imported_by, $dependent.language }
+}
+
+query import_chain($path: String)
+  @description("Files that import this file, and files that import those.")
+{
+    match {
+        $f: File { path: $path }
+        $d1 imports $f
+        $d2 imports $d1
+    }
+    return { $f.path as source, $d1.path as direct_dependent, $d2.path as transitive_dependent }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// TASK & AGENT MANAGEMENT
+// ═══════════════════════════════════════════════════════════════
+
+query agent_tasks($agent: String)
+  @description("All tasks assigned to an agent.")
+{
+    match {
+        $a: Agent { slug: $agent }
+        $a assigned $t
+    }
+    return { $t.slug, $t.title, $t.status, $t.branch, $t.priority }
+    order { $t.priority }
+}
+
+query task_files($task: String)
+  @description("All files a task modifies on its branch.")
+{
+    match {
+        $t: Task { slug: $task }
+        $t modifies $f
+    }
+    return { $t.title, $f.path, $f.language }
+    order { $f.path }
+}
+
+query task_detail($task: String)
+  @description("Full task view: agent, files modified, and reviews.")
+{
+    match {
+        $t: Task { slug: $task }
+        $a assigned $t
+        $t modifies $f
+    }
+    return { $t.title, $t.status, $t.branch, $a.name as agent, $f.path as file }
+}
+
+query active_work()
+  @description("All in-progress tasks with their agents and branches.")
+{
+    match {
+        $t: Task { status: "in_progress" }
+        $a assigned $t
+    }
+    return { $a.name as agent, $t.title, $t.branch, $t.priority }
+    order { $t.priority }
+}
+
+query open_tasks()
+  @description("Tasks not yet started.")
+{
+    match { $t: Task { status: "open" } }
+    return { $t.slug, $t.title, $t.priority, $t.description }
+    order { $t.priority }
+}
+
+query search_tasks($q: String)
+  @description("Semantic search across task descriptions.")
+  @instruction("Use to find tasks related to a concept: 'anything about rate limiting?'")
+{
+    match { $t: Task }
+    return { $t.slug, $t.title, $t.status, nearest($t.descriptionEmbedding, $q) as score }
+    order { nearest($t.descriptionEmbedding, $q) }
+    limit 5
+}
+
+// ═══════════════════════════════════════════════════════════════
+// CONFLICT DETECTION — Do any active tasks overlap?
+// ═══════════════════════════════════════════════════════════════
+
+query file_conflicts($task: String)
+  @description("Find other tasks that modify the same files as this task.")
+  @instruction("Run before merging. If results are non-empty, coordinate with the other task's agent.")
+{
+    match {
+        $t: Task { slug: $task }
+        $t modifies $f
+        $other modifies $f
+    }
+    return { $t.title as this_task, $other.slug as conflicting_task, $other.title as conflicting_title, $f.path as contested_file }
+}
+
+query import_conflicts($task: String)
+  @description("Find tasks that modify files imported by files this task modifies.")
+  @instruction("Subtler than direct conflicts: another task changed a dependency of your code.")
+{
+    match {
+        $t: Task { slug: $task }
+        $t modifies $f
+        $f imports $dep
+        $other modifies $dep
+    }
+    return { $t.title as this_task, $f.path as your_file, $dep.path as dependency, $other.title as other_task }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// REVIEW ROUTING — Who should review this?
+// ═══════════════════════════════════════════════════════════════
+
+query review_candidates($task: String)
+  @description("Find agents with expertise in modules containing files this task modifies.")
+  @instruction("Use to auto-assign reviewers. Prefer agents not assigned to the task itself.")
+{
+    match {
+        $t: Task { slug: $task }
+        $t modifies $f
+        $m contains $f
+        $expert expert $m
+    }
+    return { $t.title, $f.path as file, $m.name as module, $expert.name as reviewer }
+}
+
+query task_constraints($task: String)
+  @description("All constraints that apply to files this task modifies.")
+  @instruction("All constraints with severity=error must pass before merge.")
+{
+    match {
+        $t: Task { slug: $task }
+        $t modifies $f
+        $c governs $f
+    }
+    return { $t.title, $f.path, $c.name as constraint, $c.kind, $c.severity, $c.rule }
+}
+
+query task_reviews($task: String)
+  @description("All reviews on a task.")
+{
+    match {
+        $r: Review
+        $r reviews $t
+        $t: Task { slug: $task }
+        $r reviewedBy $a
+    }
+    return { $t.title, $r.outcome, $r.comment, $a.name as reviewer, $r.createdAt }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DECISIONS — Organizational memory
+// ═══════════════════════════════════════════════════════════════
+
+query search_decisions($q: String)
+  @description("Semantic search across past decisions.")
+  @instruction("Use when an agent asks 'why was this done this way?' or 'has anyone decided on X before?'")
+{
+    match { $d: Decision }
+    return { $d.slug, $d.summary, $d.reasoning, nearest($d.reasoningEmbedding, $q) as score }
+    order { nearest($d.reasoningEmbedding, $q) }
+    limit 5
+}
+
+query keyword_search_decisions($q: String)
+  @description("Find decisions whose reasoning contains the query tokens.")
+  @instruction("Use for exact term lookup in decision history.")
+{
+    match {
+        $d: Decision
+        search($d.reasoning, $q)
+    }
+    return { $d.slug, $d.summary, $d.decidedAt }
+    order { $d.decidedAt desc }
+}
+
+query file_decisions($path: String)
+  @description("All decisions that affect a specific file.")
+{
+    match {
+        $f: File { path: $path }
+        $d decides $f
+        $d madeBy $a
+    }
+    return { $d.summary, $d.reasoning, $a.name as decided_by, $d.decidedAt }
+    order { $d.decidedAt desc }
+}
+
+query decision_trace($task: String)
+  @description("Decisions linked to files modified by a task.")
+  @instruction("Use before starting work to understand prior design choices in the area.")
+{
+    match {
+        $t: Task { slug: $task }
+        $t modifies $f
+        $d decides $f
+        $d madeBy $a
+    }
+    return { $t.title, $f.path, $d.summary, $a.name as decided_by }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// AGENT EXPERTISE
+// ═══════════════════════════════════════════════════════════════
+
+query module_experts($mod: String)
+  @description("Who knows this module?")
+{
+    match {
+        $m: Module { slug: $mod }
+        $a expert $m
+    }
+    return { $m.name as module, $a.name as expert, $a.kind }
+}
+
+query agent_expertise($agent: String)
+  @description("What modules does this agent know?")
+{
+    match {
+        $a: Agent { slug: $agent }
+        $a expert $m
+    }
+    return { $a.name, $m.name as module, $m.path }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// AGGREGATION
+// ═══════════════════════════════════════════════════════════════
+
+query files_per_module()
+  @description("Count of files in each module.")
+{
+    match {
+        $m: Module
+        $m contains $f
+    }
+    return {
+        $m.name
+        count($f) as files
+    }
+    order { files desc }
+}
+
+query tasks_per_agent()
+  @description("Count of tasks assigned to each agent.")
+{
+    match {
+        $a: Agent
+        $a assigned $t
+    }
+    return {
+        $a.name
+        count($t) as tasks
+    }
+    order { tasks desc }
+}
+
+query most_imported()
+  @description("Files ranked by how many other files import them.")
+{
+    match {
+        $dep: File
+        $f imports $dep
+    }
+    return {
+        $dep.path
+        count($f) as importers
+    }
+    order { importers desc }
+    limit 5
+}
+
+query most_constrained()
+  @description("Files with the most constraints applied.")
+{
+    match {
+        $f: File
+        $c governs $f
+    }
+    return {
+        $f.path
+        count($c) as constraints
+    }
+    order { constraints desc }
+    limit 5
+}
+
+// ═══════════════════════════════════════════════════════════════
+// NEGATION — Find gaps
+// ═══════════════════════════════════════════════════════════════
+
+query ungoverned_files()
+  @description("Files with no constraints applied.")
+  @instruction("These files have no lint, typecheck, test, or security rules. Consider adding constraints.")
+{
+    match {
+        $f: File
+        not { $_ governs $f }
+    }
+    return { $f.path, $f.language }
+    order { $f.path }
+}
+
+query unassigned_tasks()
+  @description("Tasks with no agent assigned.")
+{
+    match {
+        $t: Task
+        not { $_ assigned $t }
+    }
+    return { $t.slug, $t.title, $t.status, $t.priority }
+}
+
+query orphan_files()
+  @description("Files not contained in any module.")
+{
+    match {
+        $f: File
+        not { $_ contains $f }
+    }
+    return { $f.path, $f.language }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// FILTERING — DateTime, Enum
+// ═══════════════════════════════════════════════════════════════
+
+query recent_tasks($since: DateTime)
+  @description("Tasks created after a given date.")
+{
+    match {
+        $t: Task
+        $t.createdAt >= $since
+    }
+    return { $t.slug, $t.title, $t.status, $t.priority, $t.createdAt }
+    order { $t.createdAt desc }
+}
+
+query recent_decisions($since: DateTime)
+  @description("Decisions made after a given date.")
+{
+    match {
+        $d: Decision
+        $d.decidedAt >= $since
+    }
+    return { $d.slug, $d.summary, $d.decidedAt }
+    order { $d.decidedAt desc }
+}
+
+query error_constraints()
+  @description("All constraints with severity = error.")
+{
+    match {
+        $c: Constraint
+        $c.severity = "error"
+    }
+    return { $c.slug, $c.name, $c.kind, $c.rule }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// MUTATIONS
+// ═══════════════════════════════════════════════════════════════
+
+query write_file($slug: String, $path: String, $language: String, $content: String, $description: String, $size: I32, $hash: String) {
+    insert File {
+        slug: $slug,
+        path: $path,
+        language: $language,
+        content: $content,
+        description: $description,
+        size: $size,
+        hash: $hash,
+        createdAt: now(),
+        updatedAt: now()
+    }
+}
+
+query update_file_content($path: String, $content: String, $size: I32, $hash: String) {
+    update File set {
+        content: $content,
+        size: $size,
+        hash: $hash,
+        updatedAt: now()
+    } where path = $path
+}
+
+query delete_file($path: String) {
+    delete File where path = $path
+}
+
+query create_task($slug: String, $title: String, $description: String, $branch: String, $priority: String) {
+    insert Task {
+        slug: $slug,
+        title: $title,
+        description: $description,
+        status: "open",
+        branch: $branch,
+        priority: $priority,
+        createdAt: now(),
+        updatedAt: now()
+    }
+}
+
+query start_task($slug: String) {
+    update Task set { status: "in_progress", updatedAt: now() } where slug = $slug
+}
+
+query submit_for_review($slug: String) {
+    update Task set { status: "in_review", updatedAt: now() } where slug = $slug
+}
+
+query merge_task($slug: String) {
+    update Task set { status: "merged", updatedAt: now() } where slug = $slug
+}
+
+query add_decision($slug: String, $summary: String, $reasoning: String) {
+    insert Decision {
+        slug: $slug,
+        summary: $summary,
+        reasoning: $reasoning,
+        decidedAt: now(),
+        createdAt: now()
+    }
+}
+
+query add_review($slug: String, $outcome: String, $comment: String) {
+    insert Review {
+        slug: $slug,
+        outcome: $outcome,
+        comment: $comment,
+        createdAt: now()
+    }
+}
+
+query add_import($from: String, $to: String, $kind: String) {
+    insert Imports { from: $from, to: $to, kind: $kind }
+}
+
+query assign_task($agent: String, $task: String) {
+    insert Assigned { from: $agent, to: $task }
+}
+
+query record_modification($task: String, $file: String, $changeType: String) {
+    insert Modifies { from: $task, to: $file, changeType: $changeType }
+}
+
+query link_decision_file($decision: String, $file: String) {
+    insert Decides { from: $decision, to: $file }
+}
+
+query link_decision_agent($decision: String, $agent: String) {
+    insert MadeBy { from: $decision, to: $agent }
+}
+
+query link_review_task($review: String, $task: String) {
+    insert Reviews { from: $review, to: $task }
+}
+
+query link_review_agent($review: String, $agent: String) {
+    insert ReviewedBy { from: $review, to: $agent }
+}

--- a/examples/codebase/codebase.jsonl
+++ b/examples/codebase/codebase.jsonl
@@ -1,0 +1,158 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Codebase Agent Workspace — JSONL Seed Data
+// Scenario: "Acme API" — a TypeScript API project with three agents working
+// concurrently on auth, billing, and refactoring tasks.
+// 36 nodes, 80 edges
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── Agents (3) ────────────────────────────────────────────────
+{"type": "Agent", "data": {"slug": "agent-claude", "name": "Claude", "kind": "ai", "model": "claude-opus-4-6", "capabilities": ["refactoring", "testing", "documentation", "security"], "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z"}}
+{"type": "Agent", "data": {"slug": "agent-devin", "name": "Devin", "kind": "ai", "model": "devin-2", "capabilities": ["feature-development", "frontend", "api-design"], "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z"}}
+{"type": "Agent", "data": {"slug": "agent-sarah", "name": "Sarah", "kind": "human", "capabilities": ["architecture", "code-review", "database", "security"], "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z"}}
+
+// ── Modules (4) ───────────────────────────────────────────────
+{"type": "Module", "data": {"slug": "mod-auth", "name": "auth", "path": "src/auth", "description": "Authentication and authorization module. Handles JWT tokens, session management, OAuth2 flows, and RBAC permission checks.", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+{"type": "Module", "data": {"slug": "mod-billing", "name": "billing", "path": "src/billing", "description": "Billing and subscription management. Stripe integration, usage metering, invoice generation, and plan enforcement.", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+{"type": "Module", "data": {"slug": "mod-api", "name": "api", "path": "src/api", "description": "REST API layer. Route definitions, request validation, rate limiting, and response serialization.", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+{"type": "Module", "data": {"slug": "mod-core", "name": "core", "path": "src/core", "description": "Shared core utilities. Database client, logger, config loader, error types, and middleware.", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+
+// ── Files (15) ────────────────────────────────────────────────
+{"type": "File", "data": {"slug": "file-auth-middleware", "path": "src/auth/middleware.ts", "language": "typescript", "content": "import { verify } from './jwt';\nimport { getPermissions } from './rbac';\nimport { AppError } from '../core/errors';\n\nexport function authMiddleware(requiredRole?: string) {\n  return async (req, res, next) => {\n    const token = req.headers.authorization?.replace('Bearer ', '');\n    if (!token) throw new AppError('UNAUTHORIZED', 401);\n    const claims = await verify(token);\n    if (requiredRole) {\n      const perms = await getPermissions(claims.sub);\n      if (!perms.includes(requiredRole)) throw new AppError('FORBIDDEN', 403);\n    }\n    req.user = claims;\n    next();\n  };\n}", "description": "Express middleware that validates JWT tokens and checks RBAC permissions. Guards API routes by extracting and verifying Bearer tokens from the Authorization header.", "size": 542, "hash": "a1b2c3d4", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-03-15T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-auth-jwt", "path": "src/auth/jwt.ts", "language": "typescript", "content": "import jwt from 'jsonwebtoken';\nimport { config } from '../core/config';\n\nexport async function sign(payload: object): Promise<string> {\n  return jwt.sign(payload, config.jwtSecret, { expiresIn: '1h' });\n}\n\nexport async function verify(token: string): Promise<JwtClaims> {\n  return jwt.verify(token, config.jwtSecret) as JwtClaims;\n}\n\nexport interface JwtClaims {\n  sub: string;\n  email: string;\n  iat: number;\n  exp: number;\n}", "description": "JWT token signing and verification using jsonwebtoken. Reads the secret from app config. Tokens expire after 1 hour.", "size": 423, "hash": "b2c3d4e5", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-02-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-auth-rbac", "path": "src/auth/rbac.ts", "language": "typescript", "content": "import { db } from '../core/db';\n\nexport async function getPermissions(userId: string): Promise<string[]> {\n  const rows = await db.query('SELECT role FROM user_roles WHERE user_id = $1', [userId]);\n  return rows.map(r => r.role);\n}\n\nexport async function hasPermission(userId: string, role: string): Promise<boolean> {\n  const perms = await getPermissions(userId);\n  return perms.includes(role);\n}", "description": "Role-based access control. Queries user roles from the database and provides permission checking helpers.", "size": 378, "hash": "c3d4e5f6", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-02-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-auth-oauth", "path": "src/auth/oauth.ts", "language": "typescript", "content": "import { sign } from './jwt';\nimport { config } from '../core/config';\nimport { db } from '../core/db';\n\nexport async function handleOAuthCallback(provider: string, code: string) {\n  const tokens = await exchangeCode(provider, code);\n  const profile = await fetchProfile(provider, tokens.access_token);\n  const user = await db.query('INSERT INTO users (email, name, provider) VALUES ($1, $2, $3) ON CONFLICT (email) DO UPDATE SET name = $2 RETURNING *', [profile.email, profile.name, provider]);\n  return sign({ sub: user[0].id, email: user[0].email });\n}", "description": "OAuth2 callback handler. Exchanges authorization codes for tokens, fetches user profiles, upserts users, and returns a signed JWT.", "size": 512, "hash": "d4e5f6a7", "createdAt": "2026-02-01T10:00:00Z", "updatedAt": "2026-02-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-billing-stripe", "path": "src/billing/stripe.ts", "language": "typescript", "content": "import Stripe from 'stripe';\nimport { config } from '../core/config';\nimport { logger } from '../core/logger';\n\nconst stripe = new Stripe(config.stripeSecretKey);\n\nexport async function createSubscription(customerId: string, priceId: string) {\n  logger.info('Creating subscription', { customerId, priceId });\n  return stripe.subscriptions.create({ customer: customerId, items: [{ price: priceId }] });\n}\n\nexport async function cancelSubscription(subscriptionId: string) {\n  return stripe.subscriptions.cancel(subscriptionId);\n}", "description": "Stripe SDK wrapper for subscription lifecycle management. Creates and cancels subscriptions, logs operations.", "size": 498, "hash": "e5f6a7b8", "createdAt": "2026-01-20T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-billing-meter", "path": "src/billing/meter.ts", "language": "typescript", "content": "import { db } from '../core/db';\nimport { logger } from '../core/logger';\n\nexport async function recordUsage(orgId: string, metric: string, quantity: number) {\n  await db.query('INSERT INTO usage_events (org_id, metric, quantity, ts) VALUES ($1, $2, $3, NOW())', [orgId, metric, quantity]);\n  logger.debug('Usage recorded', { orgId, metric, quantity });\n}\n\nexport async function getUsageSummary(orgId: string, since: Date) {\n  return db.query('SELECT metric, SUM(quantity) as total FROM usage_events WHERE org_id = $1 AND ts >= $2 GROUP BY metric', [orgId, since]);\n}", "description": "Usage metering for billing. Records per-org usage events to the database and provides aggregation queries for invoice generation.", "size": 521, "hash": "f6a7b8c9", "createdAt": "2026-01-20T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-billing-plans", "path": "src/billing/plans.ts", "language": "typescript", "content": "import { db } from '../core/db';\n\nexport const PLANS = {\n  starter: { apiCalls: 10_000, seats: 5 },\n  pro: { apiCalls: 100_000, seats: 25 },\n  enterprise: { apiCalls: Infinity, seats: Infinity },\n} as const;\n\nexport async function enforcePlanLimits(orgId: string, metric: string) {\n  const org = await db.query('SELECT plan FROM orgs WHERE id = $1', [orgId]);\n  const limits = PLANS[org[0].plan];\n  // TODO: check usage against limits\n}", "description": "Plan definitions and limit enforcement. Defines starter/pro/enterprise tiers and checks usage against plan quotas.", "size": 412, "hash": "a7b8c9d0", "createdAt": "2026-02-01T10:00:00Z", "updatedAt": "2026-02-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-api-routes", "path": "src/api/routes.ts", "language": "typescript", "content": "import { Router } from 'express';\nimport { authMiddleware } from '../auth/middleware';\nimport { createSubscription } from '../billing/stripe';\nimport { recordUsage } from '../billing/meter';\nimport { rateLimiter } from './rate-limiter';\n\nconst router = Router();\n\nrouter.use(rateLimiter());\n\nrouter.post('/subscribe', authMiddleware('billing:write'), async (req, res) => {\n  const sub = await createSubscription(req.body.customerId, req.body.priceId);\n  res.json(sub);\n});\n\nrouter.post('/usage', authMiddleware(), async (req, res) => {\n  await recordUsage(req.user.orgId, req.body.metric, req.body.quantity);\n  res.json({ ok: true });\n});\n\nexport { router };", "description": "Main API router. Mounts auth middleware and rate limiting on all routes. Exposes subscription and usage endpoints.", "size": 612, "hash": "b8c9d0e1", "createdAt": "2026-01-20T10:00:00Z", "updatedAt": "2026-03-10T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-api-rate-limiter", "path": "src/api/rate-limiter.ts", "language": "typescript", "content": "import { config } from '../core/config';\nimport { AppError } from '../core/errors';\n\nconst requests = new Map<string, number[]>();\n\nexport function rateLimiter(windowMs = 60000, max = 100) {\n  return (req, res, next) => {\n    const key = req.ip;\n    const now = Date.now();\n    const hits = (requests.get(key) || []).filter(t => t > now - windowMs);\n    if (hits.length >= max) throw new AppError('RATE_LIMITED', 429);\n    hits.push(now);\n    requests.set(key, hits);\n    next();\n  };\n}", "description": "In-memory sliding window rate limiter. Tracks request timestamps per IP and throws 429 when the window limit is exceeded.", "size": 445, "hash": "c9d0e1f2", "createdAt": "2026-01-20T10:00:00Z", "updatedAt": "2026-01-20T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-core-db", "path": "src/core/db.ts", "language": "typescript", "content": "import { Pool } from 'pg';\nimport { config } from './config';\n\nexport const db = new Pool({ connectionString: config.databaseUrl });\n", "description": "PostgreSQL connection pool using pg. Single shared pool instance configured from app config.", "size": 132, "hash": "d0e1f2a3", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-01-15T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-core-config", "path": "src/core/config.ts", "language": "typescript", "content": "export const config = {\n  port: parseInt(process.env.PORT || '3000'),\n  databaseUrl: process.env.DATABASE_URL!,\n  jwtSecret: process.env.JWT_SECRET!,\n  stripeSecretKey: process.env.STRIPE_SECRET_KEY!,\n  redisUrl: process.env.REDIS_URL,\n};", "description": "Application configuration loaded from environment variables. Central config object used across all modules.", "size": 248, "hash": "e1f2a3b4", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-03-01T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-core-errors", "path": "src/core/errors.ts", "language": "typescript", "content": "export class AppError extends Error {\n  constructor(public code: string, public statusCode: number, message?: string) {\n    super(message || code);\n  }\n}", "description": "Custom error class with HTTP status codes. Used across all modules for consistent error handling.", "size": 168, "hash": "f2a3b4c5", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-01-15T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-core-logger", "path": "src/core/logger.ts", "language": "typescript", "content": "import pino from 'pino';\nexport const logger = pino({ level: process.env.LOG_LEVEL || 'info' });", "description": "Structured JSON logger using pino. Log level configurable via environment variable.", "size": 98, "hash": "a3b4c5d6", "createdAt": "2026-01-15T10:00:00Z", "updatedAt": "2026-01-15T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-auth-middleware-test", "path": "src/auth/middleware.test.ts", "language": "typescript", "content": "import { authMiddleware } from './middleware';\nimport { verify } from './jwt';\n\njest.mock('./jwt');\n\ndescribe('authMiddleware', () => {\n  it('rejects requests without token', async () => {\n    const mw = authMiddleware();\n    const req = { headers: {} };\n    await expect(mw(req, {}, () => {})).rejects.toThrow('UNAUTHORIZED');\n  });\n\n  it('checks role permissions', async () => {\n    (verify as jest.Mock).mockResolvedValue({ sub: 'user-1' });\n    const mw = authMiddleware('admin');\n    // ...\n  });\n});", "description": "Unit tests for auth middleware. Tests token validation and RBAC permission checking.", "size": 412, "hash": "b4c5d6e7", "createdAt": "2026-02-15T10:00:00Z", "updatedAt": "2026-03-15T10:00:00Z"}}
+{"type": "File", "data": {"slug": "file-billing-webhook", "path": "src/billing/webhook.ts", "language": "typescript", "content": "import Stripe from 'stripe';\nimport { config } from '../core/config';\nimport { db } from '../core/db';\nimport { logger } from '../core/logger';\n\nexport async function handleWebhook(payload: Buffer, signature: string) {\n  const event = Stripe.webhooks.constructEvent(payload, signature, config.stripeWebhookSecret);\n  logger.info('Stripe webhook received', { type: event.type });\n  switch (event.type) {\n    case 'invoice.paid': await markInvoicePaid(event.data.object); break;\n    case 'customer.subscription.deleted': await handleChurn(event.data.object); break;\n  }\n}", "description": "Stripe webhook handler. Verifies webhook signatures and processes invoice and subscription lifecycle events.", "size": 498, "hash": "c5d6e7f8", "createdAt": "2026-03-01T10:00:00Z", "updatedAt": "2026-03-10T10:00:00Z"}}
+
+// ── Constraints (5) ───────────────────────────────────────────
+{"type": "Constraint", "data": {"slug": "con-typescript", "name": "TypeScript strict", "kind": "typecheck", "rule": "tsc --strict --noEmit", "severity": "error", "createdAt": "2026-01-15T10:00:00Z"}}
+{"type": "Constraint", "data": {"slug": "con-eslint", "name": "ESLint", "kind": "lint", "rule": "eslint --max-warnings 0", "severity": "error", "createdAt": "2026-01-15T10:00:00Z"}}
+{"type": "Constraint", "data": {"slug": "con-prettier", "name": "Prettier", "kind": "format", "rule": "prettier --check", "severity": "warning", "createdAt": "2026-01-15T10:00:00Z"}}
+{"type": "Constraint", "data": {"slug": "con-jest", "name": "Jest tests", "kind": "test", "rule": "jest --passWithNoTests", "severity": "error", "createdAt": "2026-01-15T10:00:00Z"}}
+{"type": "Constraint", "data": {"slug": "con-no-secrets", "name": "No hardcoded secrets", "kind": "security", "rule": "grep -rn 'sk_live\\|sk_test\\|password\\s*=' --include='*.ts'", "severity": "error", "createdAt": "2026-01-15T10:00:00Z"}}
+
+// ── Tasks (4) ─────────────────────────────────────────────────
+{"type": "Task", "data": {"slug": "task-refresh-tokens", "title": "Add refresh token rotation", "description": "Implement refresh token rotation to replace the current 1-hour JWT expiry. Store refresh tokens in the database with automatic rotation on use. Revoke all tokens on password change.", "status": "in_progress", "branch": "feat/refresh-tokens", "priority": "high", "createdAt": "2026-03-15T09:00:00Z", "updatedAt": "2026-03-18T14:00:00Z"}}
+{"type": "Task", "data": {"slug": "task-usage-alerts", "title": "Usage threshold alerts", "description": "Send email alerts when an organization reaches 80% and 100% of their plan's API call quota. Check usage on every API call and batch alert delivery.", "status": "in_progress", "branch": "feat/usage-alerts", "priority": "medium", "createdAt": "2026-03-16T10:00:00Z", "updatedAt": "2026-03-18T10:00:00Z"}}
+{"type": "Task", "data": {"slug": "task-redis-rate-limiter", "title": "Migrate rate limiter to Redis", "description": "Replace the in-memory rate limiter with Redis-backed sliding window. The current Map-based implementation doesn't work across multiple server instances and leaks memory.", "status": "in_review", "branch": "refactor/redis-rate-limiter", "priority": "high", "createdAt": "2026-03-14T08:00:00Z", "updatedAt": "2026-03-19T16:00:00Z"}}
+{"type": "Task", "data": {"slug": "task-webhook-idempotency", "title": "Add idempotency to Stripe webhooks", "description": "Stripe can deliver webhooks multiple times. Add an idempotency key check using the event ID to prevent duplicate processing of invoice.paid and subscription.deleted events.", "status": "open", "branch": "fix/webhook-idempotency", "priority": "medium", "createdAt": "2026-03-18T11:00:00Z", "updatedAt": "2026-03-18T11:00:00Z"}}
+
+// ── Decisions (3) — Append-only ───────────────────────────────
+{"type": "Decision", "data": {"slug": "dec-jwt-not-sessions", "summary": "Use stateless JWTs instead of server-side sessions", "reasoning": "We chose stateless JWTs over server-side sessions because our API is consumed by mobile clients and third-party integrations that can't maintain cookies. The trade-off is that we can't revoke individual tokens — logout just means the client deletes the token. This is acceptable for our current scale but we should revisit if we need instant revocation for compliance reasons.", "decidedAt": "2026-01-15T10:00:00Z", "createdAt": "2026-01-15T10:00:00Z"}}
+{"type": "Decision", "data": {"slug": "dec-stripe-only", "summary": "Use Stripe as sole payment processor", "reasoning": "Evaluated Stripe vs building on top of multiple processors. Stripe's subscription and metering APIs cover our needs without abstraction layers. The vendor lock-in risk is real but acceptable — migrating payment processors is painful regardless of abstraction. The engineering time saved by not building a payment abstraction layer is better spent on product features.", "decidedAt": "2026-01-18T10:00:00Z", "createdAt": "2026-01-18T10:00:00Z"}}
+{"type": "Decision", "data": {"slug": "dec-in-memory-rate-limiter", "summary": "Ship in-memory rate limiter as v1, migrate to Redis later", "reasoning": "The in-memory sliding window rate limiter is a known temporary solution. It doesn't work across multiple server instances and will leak memory over time. We shipped it because we needed rate limiting before launch and Redis wasn't in our infrastructure yet. Now that we're scaling to multiple instances, the Redis migration is due. The Map-based approach was explicitly marked as tech debt.", "decidedAt": "2026-01-20T10:00:00Z", "createdAt": "2026-01-20T10:00:00Z"}}
+
+// ── Reviews (2) — Append-only ─────────────────────────────────
+{"type": "Review", "data": {"slug": "rev-rate-limiter-sarah", "outcome": "changes_requested", "comment": "The Redis implementation looks solid but you're not handling the case where Redis is unavailable. Add a fallback to in-memory with a degraded mode log warning. Also add a TTL to the Redis keys so we don't leak memory there either.", "createdAt": "2026-03-19T16:00:00Z"}}
+{"type": "Review", "data": {"slug": "rev-rate-limiter-claude", "outcome": "approved", "comment": "LGTM after the fallback changes. The sliding window algorithm is correct and the Redis key structure is clean. TTL matches the window size.", "createdAt": "2026-03-20T09:00:00Z"}}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// EDGES (80)
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── Module contains File (15) ─────────────────────────────────
+{"edge": "Contains", "from": "mod-auth", "to": "file-auth-middleware"}
+{"edge": "Contains", "from": "mod-auth", "to": "file-auth-jwt"}
+{"edge": "Contains", "from": "mod-auth", "to": "file-auth-rbac"}
+{"edge": "Contains", "from": "mod-auth", "to": "file-auth-oauth"}
+{"edge": "Contains", "from": "mod-auth", "to": "file-auth-middleware-test"}
+{"edge": "Contains", "from": "mod-billing", "to": "file-billing-stripe"}
+{"edge": "Contains", "from": "mod-billing", "to": "file-billing-meter"}
+{"edge": "Contains", "from": "mod-billing", "to": "file-billing-plans"}
+{"edge": "Contains", "from": "mod-billing", "to": "file-billing-webhook"}
+{"edge": "Contains", "from": "mod-api", "to": "file-api-routes"}
+{"edge": "Contains", "from": "mod-api", "to": "file-api-rate-limiter"}
+{"edge": "Contains", "from": "mod-core", "to": "file-core-db"}
+{"edge": "Contains", "from": "mod-core", "to": "file-core-config"}
+{"edge": "Contains", "from": "mod-core", "to": "file-core-errors"}
+{"edge": "Contains", "from": "mod-core", "to": "file-core-logger"}
+
+// ── File imports File (25) ────────────────────────────────────
+{"edge": "Imports", "from": "file-auth-middleware", "to": "file-auth-jwt", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-middleware", "to": "file-auth-rbac", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-middleware", "to": "file-core-errors", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-jwt", "to": "file-core-config", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-rbac", "to": "file-core-db", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-oauth", "to": "file-auth-jwt", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-oauth", "to": "file-core-config", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-oauth", "to": "file-core-db", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-stripe", "to": "file-core-config", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-stripe", "to": "file-core-logger", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-meter", "to": "file-core-db", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-meter", "to": "file-core-logger", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-plans", "to": "file-core-db", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-webhook", "to": "file-core-config", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-webhook", "to": "file-core-db", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-billing-webhook", "to": "file-core-logger", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-api-routes", "to": "file-auth-middleware", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-api-routes", "to": "file-billing-stripe", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-api-routes", "to": "file-billing-meter", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-api-routes", "to": "file-api-rate-limiter", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-api-rate-limiter", "to": "file-core-config", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-api-rate-limiter", "to": "file-core-errors", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-core-db", "to": "file-core-config", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-middleware-test", "to": "file-auth-middleware", "data": {"kind": "static"}}
+{"edge": "Imports", "from": "file-auth-middleware-test", "to": "file-auth-jwt", "data": {"kind": "static"}}
+
+// ── Agent assigned Task (3) ───────────────────────────────────
+{"edge": "Assigned", "from": "agent-claude", "to": "task-refresh-tokens"}
+{"edge": "Assigned", "from": "agent-devin", "to": "task-usage-alerts"}
+{"edge": "Assigned", "from": "agent-claude", "to": "task-redis-rate-limiter"}
+
+// ── Task modifies File (8) ────────────────────────────────────
+{"edge": "Modifies", "from": "task-refresh-tokens", "to": "file-auth-jwt", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-refresh-tokens", "to": "file-auth-middleware", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-refresh-tokens", "to": "file-core-db", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-usage-alerts", "to": "file-billing-meter", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-usage-alerts", "to": "file-billing-plans", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-usage-alerts", "to": "file-api-routes", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-redis-rate-limiter", "to": "file-api-rate-limiter", "data": {"changeType": "updated"}}
+{"edge": "Modifies", "from": "task-redis-rate-limiter", "to": "file-core-config", "data": {"changeType": "updated"}}
+
+// ── Agent expert Module (5) ───────────────────────────────────
+{"edge": "Expert", "from": "agent-sarah", "to": "mod-auth", "data": {"confidence": "high"}}
+{"edge": "Expert", "from": "agent-sarah", "to": "mod-core", "data": {"confidence": "high"}}
+{"edge": "Expert", "from": "agent-claude", "to": "mod-api", "data": {"confidence": "medium"}}
+{"edge": "Expert", "from": "agent-devin", "to": "mod-billing", "data": {"confidence": "high"}}
+{"edge": "Expert", "from": "agent-sarah", "to": "mod-billing", "data": {"confidence": "medium"}}
+
+// ── Constraint governs File (11) ──────────────────────────────
+{"edge": "Governs", "from": "con-typescript", "to": "file-auth-middleware"}
+{"edge": "Governs", "from": "con-typescript", "to": "file-auth-jwt"}
+{"edge": "Governs", "from": "con-typescript", "to": "file-billing-stripe"}
+{"edge": "Governs", "from": "con-typescript", "to": "file-api-routes"}
+{"edge": "Governs", "from": "con-typescript", "to": "file-api-rate-limiter"}
+{"edge": "Governs", "from": "con-eslint", "to": "file-auth-middleware"}
+{"edge": "Governs", "from": "con-eslint", "to": "file-api-routes"}
+{"edge": "Governs", "from": "con-jest", "to": "file-auth-middleware-test"}
+{"edge": "Governs", "from": "con-no-secrets", "to": "file-core-config"}
+{"edge": "Governs", "from": "con-no-secrets", "to": "file-billing-stripe"}
+{"edge": "Governs", "from": "con-no-secrets", "to": "file-billing-webhook"}
+
+// ── Decision edges (8) ───────────────────────────────────────
+{"edge": "Decides", "from": "dec-jwt-not-sessions", "to": "file-auth-jwt"}
+{"edge": "Decides", "from": "dec-jwt-not-sessions", "to": "file-auth-middleware"}
+{"edge": "Decides", "from": "dec-stripe-only", "to": "file-billing-stripe"}
+{"edge": "Decides", "from": "dec-stripe-only", "to": "file-billing-webhook"}
+{"edge": "Decides", "from": "dec-in-memory-rate-limiter", "to": "file-api-rate-limiter"}
+{"edge": "MadeBy", "from": "dec-jwt-not-sessions", "to": "agent-sarah"}
+{"edge": "MadeBy", "from": "dec-stripe-only", "to": "agent-sarah"}
+{"edge": "MadeBy", "from": "dec-in-memory-rate-limiter", "to": "agent-sarah"}
+
+// ── Review edges (4) ─────────────────────────────────────────
+{"edge": "Reviews", "from": "rev-rate-limiter-sarah", "to": "task-redis-rate-limiter"}
+{"edge": "ReviewedBy", "from": "rev-rate-limiter-sarah", "to": "agent-sarah"}
+{"edge": "Reviews", "from": "rev-rate-limiter-claude", "to": "task-redis-rate-limiter"}
+{"edge": "ReviewedBy", "from": "rev-rate-limiter-claude", "to": "agent-claude"}
+
+// ── Task references (1) ──────────────────────────────────────
+{"edge": "References", "from": "task-refresh-tokens", "to": "task-redis-rate-limiter", "data": {"kind": "related_to"}}

--- a/examples/codebase/codebase.pg
+++ b/examples/codebase/codebase.pg
@@ -1,0 +1,131 @@
+// Codebase Agent Workspace — NanoGraph Schema
+// Multi-agent code collaboration graph for AI-native development.
+// 7 node types, 11 edge types.
+//
+// Models the "database as a git" paradigm: files as structured nodes,
+// agents working on branches, decisions as organizational memory,
+// and import relationships as first-class edges.
+//
+// Inspired by: gitgres (Andrew Nesbitt), Sam Hogan's agent workspace thesis.
+// Key principle: store full file content + metadata, not chunks or embeddings.
+// Agent tool calls (read, write, grep) become graph operations.
+
+// ═══════════════════════════════════════════════════════════════
+// POINTER NODES (Mutable)
+// Updated in place. All carry: slug @key, createdAt, updatedAt
+// ═══════════════════════════════════════════════════════════════
+
+node Module @description("A logical grouping of files — package, directory, or namespace.") {
+    slug: String @key
+    name: String @unique
+    path: String @description("Directory path relative to project root.")
+    description: String? @description("Human-readable summary of this module's purpose.")
+    descriptionEmbedding: Vector(8) @embed(description) @index @description("Semantic embedding for module search.")
+    createdAt: DateTime
+    updatedAt: DateTime
+}
+
+node File @description("A source file with full content. The atomic unit agents read and write.") @instruction("Store complete file content, not chunks or diffs. Agent read/write tool calls map directly to File node lookups and mutations.") {
+    slug: String @key
+    path: String @unique @description("Unique file path relative to project root.")
+    language: enum(css, go, html, javascript, json, markdown, other, python, rust, shell, sql, toml, typescript, yaml)
+    content: String @description("Full file content. Never chunked or truncated.")
+    description: String? @description("Human-readable summary of what this file does.")
+    descriptionEmbedding: Vector(8) @embed(description) @index @description("Semantic embedding for file search.")
+    size: I32 @description("Content length in bytes.")
+    hash: String @description("Content hash for change detection.")
+    createdAt: DateTime
+    updatedAt: DateTime
+}
+
+node Agent @description("A human or AI agent that performs work on the codebase.") {
+    slug: String @key
+    name: String @unique
+    kind: enum(ai, human)
+    model: String? @description("For AI agents, the model identifier.")
+    capabilities: [String]? @description("What this agent is good at: testing, refactoring, frontend, etc.")
+    createdAt: DateTime
+    updatedAt: DateTime
+}
+
+node Task @description("A unit of work performed on a branch. Maps 1:1 to a nanograph branch.") @instruction("Each Task corresponds to a nanograph branch. The branch field stores the branch name. When querying what an agent changed, traverse Task → Modifies → File.") {
+    slug: String @key
+    title: String
+    description: String? @description("What this task aims to accomplish.")
+    descriptionEmbedding: Vector(8) @embed(description) @index @description("Semantic embedding for task search.")
+    status: enum(abandoned, in_progress, in_review, merged, open)
+    branch: String @description("The nanograph branch name where this work happens.")
+    priority: enum(critical, high, low, medium)?
+    createdAt: DateTime
+    updatedAt: DateTime
+}
+
+node Constraint @description("A rule that must pass before a branch can merge.") @instruction("Constraints govern files. Before merging a Task's branch, query all Constraints that Govern any File the Task Modifies. All must pass.") {
+    slug: String @key
+    name: String @unique
+    kind: enum(format, lint, review, security, test, typecheck)
+    rule: String @description("The constraint definition — a command, pattern, or policy.")
+    severity: enum(error, info, warning)
+    createdAt: DateTime
+}
+
+// ═══════════════════════════════════════════════════════════════
+// APPEND-ONLY NODES (Immutable)
+// Never overwritten. Corrections create new records.
+// All carry: slug @key, createdAt (no updatedAt)
+// ═══════════════════════════════════════════════════════════════
+
+node Decision @description("Append-only record of why something was designed or changed a certain way.") @instruction("Never overwrite decisions. They are organizational memory. Embed reasoning for semantic search: 'why did we choose this approach?'") {
+    slug: String @key
+    summary: String @description("One-line summary of the decision.")
+    reasoning: String @description("Detailed rationale — the part worth remembering.")
+    reasoningEmbedding: Vector(8) @embed(reasoning) @index @description("Semantic embedding for decision search.")
+    decidedAt: DateTime
+    createdAt: DateTime
+}
+
+node Review @description("A review verdict on a task branch. Append-only — each review round creates a new record.") {
+    slug: String @key
+    outcome: enum(approved, blocked, changes_requested)
+    comment: String? @description("Review feedback or approval note.")
+    createdAt: DateTime
+}
+
+// ═══════════════════════════════════════════════════════════════
+// EDGES — Structure
+// ═══════════════════════════════════════════════════════════════
+
+edge Contains: Module -> File @description("A module contains a file.")
+
+edge Imports: File -> File @description("Source file imports or depends on target file.") @instruction("Maintain on write: when an agent modifies a file's imports, update these edges. Enables blast radius queries.") {
+    kind: enum(dynamic, static, type_only)?
+}
+
+// ═══════════════════════════════════════════════════════════════
+// EDGES — Work
+// ═══════════════════════════════════════════════════════════════
+
+edge Assigned: Agent -> Task @description("Agent is assigned to work on a task.")
+
+edge Modifies: Task -> File @description("Task modifies this file on its branch.") {
+    changeType: enum(created, deleted, updated)
+}
+
+edge Expert: Agent -> Module @description("Agent has expertise in this module. Used for review routing.") {
+    confidence: enum(high, low, medium)
+}
+
+edge Governs: Constraint -> File @description("This constraint must pass for this file.")
+
+// ═══════════════════════════════════════════════════════════════
+// EDGES — Collaboration
+// ═══════════════════════════════════════════════════════════════
+
+edge Decides: Decision -> File @description("This decision explains a design choice in this file.")
+edge MadeBy: Decision -> Agent @description("Who made or proposed this decision.")
+edge Reviews: Review -> Task @description("Review verdict on a task's branch.")
+edge ReviewedBy: Review -> Agent @description("Who performed the review.")
+
+edge References: Task -> Task @description("Task references or depends on another task.") {
+    kind: enum(blocks, depends_on, related_to)
+}

--- a/examples/codebase/nanograph.toml
+++ b/examples/codebase/nanograph.toml
@@ -1,0 +1,164 @@
+[project]
+name = "Codebase Agent Workspace"
+description = "Multi-agent code collaboration graph. Files as nodes, imports as edges, agents on branches."
+instruction = "Run commands from this directory. Queries model agent tool calls: read, write, search, blast radius, conflict detection, review routing."
+
+[db]
+default_path = "codebase.nano"
+
+[schema]
+default_path = "codebase.pg"
+
+[query]
+roots = ["."]
+
+[embedding]
+provider = "mock"
+chunk_size = 1500
+chunk_overlap_chars = 200
+
+[cli]
+output_format = "table"
+
+# ── File operations (agent tool call equivalents) ──────────────
+
+[query_aliases.read]
+query = "codebase.gq"
+name = "read_file"
+args = ["path"]
+format = "kv"
+
+[query_aliases.ls]
+query = "codebase.gq"
+name = "list_files"
+args = ["mod"]
+format = "table"
+
+[query_aliases.find]
+query = "codebase.gq"
+name = "semantic_search_files"
+args = ["q"]
+format = "table"
+
+[query_aliases.search]
+query = "codebase.gq"
+name = "hybrid_search_files"
+args = ["q"]
+format = "table"
+
+# ── Import graph ───────────────────────────────────────────────
+
+[query_aliases.deps]
+query = "codebase.gq"
+name = "file_dependencies"
+args = ["path"]
+format = "table"
+
+[query_aliases.dependents]
+query = "codebase.gq"
+name = "file_dependents"
+args = ["path"]
+format = "table"
+
+[query_aliases.blast]
+query = "codebase.gq"
+name = "import_chain"
+args = ["path"]
+format = "table"
+
+# ── Task management ───────────────────────────────────────────
+
+[query_aliases.tasks]
+query = "codebase.gq"
+name = "agent_tasks"
+args = ["agent"]
+format = "table"
+
+[query_aliases.files]
+query = "codebase.gq"
+name = "task_files"
+args = ["task"]
+format = "table"
+
+[query_aliases.active]
+query = "codebase.gq"
+name = "active_work"
+format = "table"
+
+[query_aliases.detail]
+query = "codebase.gq"
+name = "task_detail"
+args = ["task"]
+format = "table"
+
+# ── Conflict detection ────────────────────────────────────────
+
+[query_aliases.conflicts]
+query = "codebase.gq"
+name = "file_conflicts"
+args = ["task"]
+format = "table"
+
+[query_aliases.dep-conflicts]
+query = "codebase.gq"
+name = "import_conflicts"
+args = ["task"]
+format = "table"
+
+# ── Review routing ─────────────────────────────────────────────
+
+[query_aliases.reviewers]
+query = "codebase.gq"
+name = "review_candidates"
+args = ["task"]
+format = "table"
+
+[query_aliases.checks]
+query = "codebase.gq"
+name = "task_constraints"
+args = ["task"]
+format = "table"
+
+[query_aliases.reviews]
+query = "codebase.gq"
+name = "task_reviews"
+args = ["task"]
+format = "table"
+
+# ── Decisions ──────────────────────────────────────────────────
+
+[query_aliases.why]
+query = "codebase.gq"
+name = "search_decisions"
+args = ["q"]
+format = "kv"
+
+[query_aliases.history]
+query = "codebase.gq"
+name = "file_decisions"
+args = ["path"]
+format = "kv"
+
+# ── Aggregation ────────────────────────────────────────────────
+
+[query_aliases.stats]
+query = "codebase.gq"
+name = "files_per_module"
+format = "table"
+
+[query_aliases.hotspots]
+query = "codebase.gq"
+name = "most_imported"
+format = "table"
+
+# ── Gaps ───────────────────────────────────────────────────────
+
+[query_aliases.ungoverned]
+query = "codebase.gq"
+name = "ungoverned_files"
+format = "table"
+
+[query_aliases.unassigned]
+query = "codebase.gq"
+name = "unassigned_tasks"
+format = "table"


### PR DESCRIPTION
## Summary

- Adds a new example: **Codebase Agent Workspace** — a multi-agent code collaboration graph
- Models the "database as a git" paradigm: files as structured nodes, imports as edges, agents on branches
- 7 node types, 11 edge types, 52 queries (36 read + 16 mutation)
- Follows conventions from `revops` and `starwars` examples: pointer vs append-only nodes, `@description`/`@instruction` annotations, keyword/semantic/hybrid search, aggregation, negation, date filtering

## What it demonstrates

| Feature | Queries |
|---------|---------|
| Hybrid search (keyword + semantic + rrf) | `keyword_search_files`, `semantic_search_files`, `hybrid_search_files` |
| Multi-hop traversal | `import_chain` (two-hop blast radius) |
| Cross-entity join | `review_candidates` (Task→File→Module→Agent), `file_conflicts` (Task→File←Task) |
| Aggregation | `files_per_module`, `most_imported`, `tasks_per_agent`, `most_constrained` |
| Negation | `ungoverned_files`, `unassigned_tasks`, `orphan_files` |
| Date filtering | `recent_tasks`, `recent_decisions` |
| Append-only events | `Decision`, `Review` nodes (no `updatedAt`) |
| Edge properties | `Imports.kind`, `Modifies.changeType`, `Expert.confidence`, `References.kind` |

## Seed data scenario

"Acme API" — a TypeScript project with 3 agents (Claude, Devin, Sarah) working concurrently on 4 tasks across 15 files in 4 modules. The data is designed to show:

1. **Conflict detection** — two agents modifying files connected through the import graph
2. **Review routing** — expertise edges auto-route reviews to the right human
3. **Organizational memory** — past decisions explain why code was designed a certain way
4. **Constraint checking** — lint/typecheck/security rules scoped to specific files

## Test plan

- [ ] `nanograph init && nanograph load --data codebase.jsonl --mode overwrite && nanograph embed`
- [ ] `nanograph check --query codebase.gq` — all 52 queries pass
- [ ] `nanograph doctor --verbose` — all datasets v2.2, no errors
- [ ] `nanograph run active` / `nanograph run blast src/auth/jwt.ts` / `nanograph run conflicts task-usage-alerts` return expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)