### PR TITLE
Swift SDK mutation helpers + @key-aware edge endpoint lookup

### DIFF
--- a/BUG-path-spaces.md
+++ b/BUG-path-spaces.md
@@ -1,0 +1,278 @@
+# Bug: paths with spaces break Lance namespace resolution
+
+## Summary
+
+Any `Database::init` / `Database::open` on a path whose filesystem location
+contains a space character fails when subsequent operations try to open the
+internal `__graph_snapshot` / `__graph_tx` / `__graph_deletes` Lance datasets.
+
+This affects every macOS user, because `~/Library/Application Support/` — the
+canonical location for app-private data on macOS — contains a literal space.
+It also affects user-chosen paths like `~/Documents/My Graph.nano`.
+
+## Reproducer
+
+```sh
+$ cargo run -p nanograph-cli -- init "/tmp/with spaces.nano" --schema crates/nanograph/tests/fixtures/test.pg
+Error: lance error: open staged dataset __graph_snapshot error:
+  Dataset at path tmp/with spaces.nano/bbf0e98a___graph_snapshot was not found:
+  Not found: tmp/with spaces.nano/bbf0e98a___graph_snapshot/_versions, ...
+
+$ cargo run -p nanograph-cli -- init "/tmp/no-space.nano" --schema crates/nanograph/tests/fixtures/test.pg
+OK: Initialized database at /tmp/no-space.nano
+```
+
+Notice in the failing case:
+
+1. The leading `/` is missing (`tmp/...` instead of `/tmp/...`).
+2. The path is URL-decoded *inside* the error message — `with spaces` stays
+   as a literal space rather than `%20`. But when the same operation is
+   triggered from a path that was already percent-encoded by macOS's
+   `NSFileManager` (e.g. `Application%20Support`), the `%20` *survives* into
+   the Lance lookup, and the directory search fails because the real
+   filesystem entry has a literal space.
+
+Both symptoms point at the same root cause: nanograph hands a POSIX path to
+Lance where Lance expects a URI.
+
+## Root cause
+
+`crates/nanograph/src/store/namespace.rs:58`:
+
+```rust
+pub(crate) async fn open_directory_namespace(db_path: &Path) -> Result<Arc<dyn LanceNamespace>> {
+    let namespace = DirectoryNamespaceBuilder::new(db_path.to_string_lossy().to_string())
+        .manifest_enabled(true)
+        .dir_listing_enabled(false)
+        .table_version_tracking_enabled(true)
+        .table_version_storage_enabled(true)
+        .inline_optimization_enabled(true)
+        .build()
+        .await
+        .map_err(|err| NanoError::Lance(format!("open directory namespace error: {}", err)))?;
+    Ok(Arc::new(namespace))
+}
+```
+
+`DirectoryNamespaceBuilder::new(...)` is expecting a URI string. Passing a
+POSIX path that happens to have no space characters works by accident —
+every character is URI-legal, so URL parsing yields the same string back.
+Once the path contains any reserved character (space is the most common;
+`#`, `?`, `%`, `[`, `]` are all also illegal in unescaped URIs), Lance's
+parsing drifts from the actual filesystem path.
+
+## Better implementation proposal
+
+This should be treated as a URI/path normalization fix, not just a one-line
+`file://` wrapper.
+
+### Goals
+
+1. Always give Lance a proper `file://` URI when opening a local
+   `DirectoryNamespace`.
+2. Keep compatibility with existing nanograph code and older local DBs that
+   may still hold plain filesystem paths.
+3. Stop using `strip_prefix("file://")` as a fake URI parser, because that
+   does not decode `%20` back into a real space.
+
+### Why the simple fix is incomplete
+
+Changing only this:
+
+```rust
+DirectoryNamespaceBuilder::new(db_path.to_string_lossy().to_string())
+```
+
+to this:
+
+```rust
+DirectoryNamespaceBuilder::new(Url::from_file_path(db_path)?.to_string())
+```
+
+is not enough.
+
+Today nanograph has many places that do this pattern:
+
+```rust
+let normalized = location.strip_prefix("file://").unwrap_or(location);
+let path = PathBuf::from(normalized);
+```
+
+That works only for raw filesystem paths. Once the namespace starts returning
+real URIs like:
+
+```text
+file:///tmp/with%20spaces.nano/__graph_snapshot.lance
+```
+
+the current code turns that into:
+
+```text
+/tmp/with%20spaces.nano/__graph_snapshot.lance
+```
+
+which is still wrong on disk.
+
+So the fix needs two parts:
+
+1. encode local DB roots as proper `file://` URIs on the way into Lance
+2. decode `file://` URIs back into real filesystem paths on the way out
+
+### Recommended implementation shape
+
+Add two small helpers in `crates/nanograph/src/store/namespace.rs` and make
+them the only path/URI bridge for namespace code.
+
+```rust
+use std::path::{Path, PathBuf};
+use url::Url;
+
+fn absolutize_local_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()?.join(path))
+}
+
+pub(crate) fn local_path_to_file_uri(path: &Path) -> Result<String> {
+    let absolute = absolutize_local_path(path)?;
+    let url = Url::from_directory_path(&absolute).map_err(|_| {
+        NanoError::Lance(format!(
+            "failed to convert database path to file URI: {}",
+            absolute.display()
+        ))
+    })?;
+    Ok(url.to_string().trim_end_matches('/').to_string())
+}
+
+pub(crate) fn namespace_location_to_local_path(
+    db_dir: &Path,
+    location: &str,
+) -> Result<PathBuf> {
+    if let Ok(url) = Url::parse(location) {
+        if url.scheme() == "file" {
+            return url.to_file_path().map_err(|_| {
+                NanoError::Lance(format!(
+                    "failed to convert file URI to local path: {}",
+                    location
+                ))
+            });
+        }
+    }
+
+    // Backward-compat path for older plain-path values.
+    let path = PathBuf::from(location);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(absolutize_local_path(db_dir)?.join(path))
+    }
+}
+```
+
+Then change `open_directory_namespace(...)` to use the URI helper:
+
+```rust
+pub(crate) async fn open_directory_namespace(db_path: &Path) -> Result<Arc<dyn LanceNamespace>> {
+    let root_uri = local_path_to_file_uri(db_path)?;
+    let namespace = DirectoryNamespaceBuilder::new(root_uri)
+        .manifest_enabled(true)
+        .dir_listing_enabled(false)
+        .table_version_tracking_enabled(true)
+        .table_version_storage_enabled(true)
+        .inline_optimization_enabled(true)
+        .build()
+        .await
+        .map_err(|err| NanoError::Lance(format!("open directory namespace error: {}", err)))?;
+    Ok(Arc::new(namespace))
+}
+```
+
+### Important compatibility note
+
+Do not require absolute paths at the public API boundary. `Database::init`
+currently accepts relative paths, so the helper should absolutize them before
+converting to a URI.
+
+### Required follow-up refactor
+
+Replace every local pattern like this:
+
+```rust
+location.strip_prefix("file://").unwrap_or(location)
+PathBuf::from(...)
+```
+
+with the shared helper above.
+
+At minimum, this needs to be updated in:
+
+- `store/snapshot.rs`
+- `store/namespace_commit.rs`
+- `store/v4_graph_log.rs`
+- `store/namespace_lineage_graph_log.rs`
+- `store/lance_io.rs`
+- `store/blob_store.rs`
+- `store/storage_migrate.rs`
+- `store/migration.rs`
+- `store/database/persist.rs`
+
+That keeps the change surgical but complete.
+
+### Dependency note
+
+If nanograph imports `url::Url` directly, `url` should be added as a direct
+dependency. Being transitive via Lance is not enough for Rust source usage.
+
+## Regression test
+
+Something like:
+
+```rust
+#[tokio::test]
+async fn database_works_with_path_containing_spaces() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("my folder/db.nano");
+
+    let db = Database::init(&db_path, TEST_SCHEMA).await.unwrap();
+    db.load(TEST_JSONL).await.unwrap();
+
+    let reopened = Database::open(&db_path).await.unwrap();
+    let _ = reopened.changes(0, None).await.unwrap();
+}
+
+#[tokio::test]
+async fn database_works_with_reserved_chars_in_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("hash#percent%db/db.nano");
+
+    let db = Database::init(&db_path, TEST_SCHEMA).await.unwrap();
+    db.load(TEST_JSONL).await.unwrap();
+
+    let reopened = Database::open(&db_path).await.unwrap();
+    let _ = reopened.changes(0, None).await.unwrap();
+}
+```
+
+## Blast radius
+
+This is still the right surgical fix point.
+
+`open_directory_namespace(...)` is the shared source for local namespace
+construction across the storage stack, and it is used by many callers across
+`store/` (`snapshot`, `namespace_commit`, `lance_io`, `blob_store`,
+`storage_migrate`, graph-log code, maintenance, migration, and tests).
+
+So the blast radius is broad in effect, but narrow in implementation:
+
+1. fix the URI construction at `open_directory_namespace(...)`
+2. replace ad hoc `file://` string stripping with one real URI-to-path helper
+
+## Observed in
+
+- macOS 26 (Tahoe), APFS case-insensitive.
+- Reproduces via both `nanograph-cli` directly and through `nanograph-ffi`
+  → Swift SDK.
+- Reported while integrating nanograph into a sandboxed Mac app, where the
+  only writable per-app container path (`~/Library/Containers/<id>/Data/Library/Application Support/`)
+  contains a space and triggered this on every launch.

--- a/crates/nanograph-cli/src/tests.rs
+++ b/crates/nanograph-cli/src/tests.rs
@@ -2143,7 +2143,7 @@ query remove_work($from: String) {
     let results = execute_run_query_batches(
         &db_path,
         &queries.queries[0],
-        &ParamMap::from([("from".to_string(), Literal::String("Alice".to_string()))]),
+        &ParamMap::from([("from".to_string(), Literal::String("alice".to_string()))]),
     )
     .await
     .unwrap();
@@ -2163,6 +2163,83 @@ query remove_work($from: String) {
     let delete_row = change_rows.last().unwrap();
     assert_eq!(delete_row.change_kind, "delete");
     assert_eq!(delete_row.type_name, "WorksAt");
+}
+
+#[tokio::test]
+async fn run_delete_edge_missing_endpoint_returns_zero_affected_without_error() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let schema_path = dir.path().join("schema.pg");
+    let data_path = dir.path().join("data.jsonl");
+    let query_path = dir.path().join("delete-edge.gq");
+
+    write_file(
+        &schema_path,
+        r#"node Person {
+    slug: String @key
+    name: String
+}
+node Company {
+    slug: String @key
+    name: String
+}
+edge Knows: Person -> Person
+edge WorksAt: Person -> Company"#,
+    );
+    write_file(
+        &data_path,
+        r#"{"type":"Person","data":{"slug":"alice","name":"Alice"}}
+{"type":"Person","data":{"slug":"bob","name":"Bob"}}
+{"type":"Company","data":{"slug":"acme","name":"Acme"}}
+{"edge":"Knows","from":"alice","to":"bob"}
+{"edge":"WorksAt","from":"alice","to":"acme"}"#,
+    );
+    write_file(
+        &query_path,
+        r#"
+query remove_work($from: String) {
+    delete WorksAt where from = $from
+}
+"#,
+    );
+
+    cmd_init(&db_path, &schema_path, false, false)
+        .await
+        .unwrap();
+    cmd_load(&db_path, &data_path, LoadModeArg::Overwrite, false, false)
+        .await
+        .unwrap();
+
+    let metadata = DatabaseMetadata::open(&db_path).unwrap();
+    let knows_dataset_path = metadata
+        .manifest()
+        .datasets
+        .iter()
+        .find(|entry| entry.kind == "edge" && entry.type_name == "Knows")
+        .map(|entry| entry.dataset_path.clone())
+        .unwrap();
+    std::fs::remove_dir_all(db_path.join(knows_dataset_path)).unwrap();
+
+    let query_src = std::fs::read_to_string(&query_path).unwrap();
+    let queries = parse_query_or_report(&query_path, &query_src).unwrap();
+    let results = execute_run_query_batches(
+        &db_path,
+        &queries.queries[0],
+        &ParamMap::from([("from".to_string(), Literal::String("nobody".to_string()))]),
+    )
+    .await
+    .unwrap();
+    let affected_edges = results[0]
+        .column_by_name("affected_edges")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow_array::UInt64Array>()
+        .unwrap();
+    assert_eq!(affected_edges.value(0), 0);
+
+    let metadata = DatabaseMetadata::open(&db_path).unwrap();
+    let works_at = build_describe_payload(&db_path, &metadata, Some("WorksAt")).unwrap();
+    assert_eq!(works_at["edges"][0]["rows"].as_u64(), Some(1));
 }
 
 #[tokio::test]

--- a/crates/nanograph-ffi/swift/Sources/CNanoGraph/CNanoGraph.c
+++ b/crates/nanograph-ffi/swift/Sources/CNanoGraph/CNanoGraph.c
@@ -1,0 +1,8 @@
+// This translation unit exists only so SwiftPM emits a CNanoGraph object
+// file. Xcode's SPM integration (Xcode 15+) treats C targets with no
+// sources as an error when consuming the package from a .xcodeproj, even
+// though `swift build` handles headers-only targets fine. All real
+// symbols come from the Rust `libnanograph_ffi` dylib linked in
+// NanoGraph's linkerSettings; this file is intentionally empty.
+
+void _cnanograph_anchor(void) {}

--- a/crates/nanograph-ffi/swift/Sources/NanoGraph/NanoGraph.swift
+++ b/crates/nanograph-ffi/swift/Sources/NanoGraph/NanoGraph.swift
@@ -153,6 +153,89 @@ public struct MutationResult: Decodable, Sendable {
     }
 }
 
+/// A single committed mutation in the CDC log.
+///
+/// Mirrors the Rust-side `VisibleChangeRow` in
+/// `crates/nanograph/src/store/txlog.rs`. Field names use snake_case on the
+/// wire; Swift surfaces them as camelCase via `CodingKeys`.
+///
+/// The cursor for resuming a stream is `graphVersion` — monotonic across a
+/// database's lifetime, unique per commit.
+public struct Change: Decodable, Sendable {
+    public enum Kind: String, Decodable, Sendable {
+        case insert, update, delete
+    }
+
+    public enum EntityKind: String, Decodable, Sendable {
+        case node, edge
+    }
+
+    public let graphVersion: UInt64
+    public let txId: String
+    public let committedAt: String
+    public let changeKind: Kind
+    public let entityKind: EntityKind
+    public let typeName: String
+    public let tableId: String
+    public let rowid: UInt64
+    public let entityId: UInt64
+    public let logicalKey: String
+    public let row: JSONValue?
+    public let previousGraphVersion: UInt64?
+
+    private enum CodingKeys: String, CodingKey {
+        case graphVersion = "graph_version"
+        case txId = "tx_id"
+        case committedAt = "committed_at"
+        case changeKind = "change_kind"
+        case entityKind = "entity_kind"
+        case typeName = "type_name"
+        case tableId = "table_id"
+        case rowid
+        case entityId = "entity_id"
+        case logicalKey = "logical_key"
+        case row
+        case previousGraphVersion = "previous_graph_version"
+    }
+}
+
+/// A type-erased JSON value, suitable for exposing opaque payloads (like the
+/// `row` field on a `Change`) to callers without forcing a schema-specific
+/// decoder. Supports `null`, bools, numbers, strings, arrays, and objects.
+public enum JSONValue: Decodable, Sendable {
+    case null
+    case bool(Bool)
+    case int(Int64)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int64.self) {
+            self = .int(int)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([JSONValue].self) {
+            self = .array(array)
+        } else if let object = try? container.decode([String: JSONValue].self) {
+            self = .object(object)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+}
+
 public final class Database {
     // Serializes handle lifecycle/use to avoid close-vs-operation races.
     private let lock = NSLock()
@@ -439,6 +522,71 @@ public final class Database {
     public func changes<T: Decodable>(_ type: T.Type, options: Any? = nil) throws -> T {
         let raw = try changes(options: options)
         return try decodeValue(type, from: raw)
+    }
+
+    /// Fetch the CDC log since a given `graph_version` cursor. Pass `nil` to
+    /// fetch everything from the beginning.
+    ///
+    /// The returned array is ordered by `graphVersion` ascending (engine
+    /// contract); callers can advance their cursor with `.max(by:)` on the
+    /// returned rows.
+    public func changes(since graphVersion: UInt64? = nil) throws -> [Change] {
+        var options: [String: Any] = [:]
+        if let graphVersion {
+            options["since"] = graphVersion
+        }
+        return try changes([Change].self, options: options.isEmpty ? nil : options)
+    }
+
+    /// Returns the current (highest committed) `graph_version` — useful for
+    /// seeding a CDC stream cursor after an initial hydrate so the first poll
+    /// doesn't replay history.
+    ///
+    /// Implementation: reads the full change log once. Cheap on fresh DBs;
+    /// consider caching this at the call site for high-traffic loops.
+    public func currentGraphVersion() throws -> UInt64? {
+        let allChanges = try changes(since: nil)
+        return allChanges.map(\.graphVersion).max()
+    }
+
+    /// A polling AsyncSequence over the CDC log. Every `interval`, fetches
+    /// any new `Change` rows since the last seen cursor and yields them as a
+    /// batch. Quiet DBs produce empty polls that yield nothing (non-empty
+    /// batches only are yielded).
+    ///
+    /// The sequence terminates when the Task consuming it is cancelled.
+    ///
+    /// `startAt`: seed cursor — typically the `graph_version` of the most
+    /// recent state the consumer has already applied. Pass `nil` to replay
+    /// from the beginning.
+    public func changeStream(
+        interval: Duration = .seconds(1.5),
+        startAt cursor: UInt64? = nil
+    ) -> AsyncThrowingStream<[Change], Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { [self] in
+                var currentCursor = cursor
+                while !Task.isCancelled {
+                    do {
+                        let batch = try self.changes(since: currentCursor)
+                        if !batch.isEmpty {
+                            continuation.yield(batch)
+                            currentCursor = batch.map(\.graphVersion).max() ?? currentCursor
+                        }
+                    } catch {
+                        continuation.finish(throwing: error)
+                        return
+                    }
+                    do {
+                        try await Task.sleep(for: interval)
+                    } catch {
+                        break
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
     }
 
     private func requireHandleLocked() throws -> OpaquePointer {

--- a/crates/nanograph-ffi/swift/Sources/NanoGraph/NanoGraph.swift
+++ b/crates/nanograph-ffi/swift/Sources/NanoGraph/NanoGraph.swift
@@ -121,11 +121,21 @@ public enum LoadRow {
 private struct SchemaDescribeMetadata: Decodable {
     struct TypeDef: Decodable {
         let name: String
+        let keyProperty: String?
+        let endpointKeys: EndpointKeys?
+        let srcType: String?
+        let dstType: String?
         let properties: [Property]
+    }
+
+    struct EndpointKeys: Decodable {
+        let src: String?
+        let dst: String?
     }
 
     struct Property: Decodable {
         let name: String
+        let type: String?
         let mediaMimeProp: String?
     }
 
@@ -133,10 +143,21 @@ private struct SchemaDescribeMetadata: Decodable {
     let edgeTypes: [TypeDef]
 }
 
+public struct MutationResult: Decodable, Sendable {
+    public let affectedNodes: Int
+    public let affectedEdges: Int
+
+    public init(affectedNodes: Int, affectedEdges: Int) {
+        self.affectedNodes = affectedNodes
+        self.affectedEdges = affectedEdges
+    }
+}
+
 public final class Database {
     // Serializes handle lifecycle/use to avoid close-vs-operation races.
     private let lock = NSLock()
     private var handle: OpaquePointer?
+    private var cachedSchema: SchemaDescribeMetadata?
 
     private init(handle: OpaquePointer) {
         self.handle = handle
@@ -194,7 +215,20 @@ public final class Database {
             }
             nanograph_db_destroy(handle)
             self.handle = nil
+            cachedSchema = nil
         }
+    }
+
+    /// Lazy, per-instance cache of the schema metadata used by mutation
+    /// helpers. Populated on first use; invalidated by `close()`.
+    fileprivate func cachedSchemaMetadata() throws -> SchemaDescribeMetadata {
+        if let cached = lock.withLock({ self.cachedSchema }) {
+            return cached
+        }
+        // Compute outside the lock — `describe` takes its own lock internally.
+        let schema = try describe(SchemaDescribeMetadata.self)
+        lock.withLock { self.cachedSchema = schema }
+        return schema
     }
 
     public func load(dataSource: String, mode: LoadMode) throws {
@@ -440,6 +474,309 @@ public final class Database {
             nanograph_bytes_free(bytes)
         }
         return Data(bytes: ptr, count: Int(bytes.len))
+    }
+}
+
+// MARK: - Tier 1 mutation helpers
+//
+// Each helper synthesizes a named .gq query, executes it through the existing
+// `run(querySource:queryName:params:)` FFI entry point, and decodes the
+// `{affectedNodes, affectedEdges}` payload that the engine returns for
+// mutation queries (see `MutationResult::to_sdk_json` in the core crate).
+//
+// Zero-match deletes return `affectedNodes: 0` silently — the engine treats
+// missing rows as a no-op, not an error. See `crates/nanograph/src/store/
+// database/persist.rs:949-966`.
+
+extension Database {
+    /// Insert or fully replace a node keyed by its `@key` property.
+    ///
+    /// **This is a full-row replace**, not a partial merge. Per the core
+    /// loader's keyed-merge semantics (see `crates/nanograph/src/store/loader/
+    /// merge.rs`), the incoming row overwrites every column — unmentioned
+    /// non-null columns that are required by the schema will fail validation.
+    /// For partial edits that preserve existing columns, use `updateNode`.
+    public func upsertNode(type: String, data: [String: Any]) throws {
+        try loadRows([.node(type: type, data: data)], mode: .merge)
+    }
+
+    /// Insert or fully replace an edge keyed by `(from, to)`. Re-writing the
+    /// same `(from, to)` pair with different property values (e.g. a new
+    /// `position` for outline reordering) overwrites the existing row.
+    ///
+    /// Identity is `(from, to)` — this is **not a multigraph**. Two parallel
+    /// edges between the same pair collapse to one.
+    ///
+    /// Edge properties written here cannot currently be projected back through
+    /// `.gq` queries (the grammar lacks an edge-binding form), only through
+    /// the CDC `changes()` stream or raw Lance reads.
+    public func upsertEdge(
+        type: String,
+        from: String,
+        to: String,
+        data: [String: Any] = [:]
+    ) throws {
+        try loadRows([.edge(type: type, from: from, to: to, data: data)], mode: .merge)
+    }
+
+    /// Delete a single node by its `@key`. Cascades all incident edges across
+    /// edge types and directions. Silent no-op on miss.
+    @discardableResult
+    public func deleteNode(type: String, key: Any) throws -> MutationResult {
+        let (nodeDef, keyTypeAnn) = try nodeKeyMetadata(for: type)
+        let keyProperty = try requireKeyProperty(for: nodeDef)
+        let querySource = """
+        query __sdk_delete_node($__key: \(keyTypeAnn)) {
+          delete \(type) where \(keyProperty) = $__key
+        }
+        """
+        return try runMutation(
+            querySource: querySource,
+            queryName: "__sdk_delete_node",
+            params: ["__key": key]
+        )
+    }
+
+    /// Delete every edge of `type` whose source endpoint matches `key`.
+    ///
+    /// Grammar limitation: `.gq` `where` clauses on mutations accept a **single**
+    /// `ident op value` predicate (see `query.pest: mutation_predicate`), so
+    /// there's no single-edge delete-by-(from, to) today. Callers that want
+    /// to sever a specific parent-child link should pair this with a semantic
+    /// model where one endpoint uniquely identifies the edge (e.g. an outline
+    /// where a child has at most one structural parent — `deleteEdgesTo(type:
+    /// "Contains", key: childKey)` cleanly unparents).
+    @discardableResult
+    public func deleteEdgesFrom(type: String, key: Any) throws -> MutationResult {
+        let edgeDef = try edgeTypeDefinition(for: type)
+        let annotations = try edgeEndpointKeyTypeAnnotations(for: edgeDef)
+        let querySource = """
+        query __sdk_delete_edges_from($__from: \(annotations.src)) {
+          delete \(type) where from = $__from
+        }
+        """
+        return try runMutation(
+            querySource: querySource,
+            queryName: "__sdk_delete_edges_from",
+            params: ["__from": key]
+        )
+    }
+
+    /// Delete every edge of `type` whose target endpoint matches `key`.
+    ///
+    /// See `deleteEdgesFrom(type:key:)` for the grammar-limit rationale.
+    @discardableResult
+    public func deleteEdgesTo(type: String, key: Any) throws -> MutationResult {
+        let edgeDef = try edgeTypeDefinition(for: type)
+        let annotations = try edgeEndpointKeyTypeAnnotations(for: edgeDef)
+        let querySource = """
+        query __sdk_delete_edges_to($__to: \(annotations.dst)) {
+          delete \(type) where to = $__to
+        }
+        """
+        return try runMutation(
+            querySource: querySource,
+            queryName: "__sdk_delete_edges_to",
+            params: ["__to": key]
+        )
+    }
+
+    /// Update properties on a single node identified by its `@key`. The key
+    /// itself is immutable — attempting to include it in `set` is rejected
+    /// client-side before hitting the engine.
+    ///
+    /// Unmentioned properties are preserved (the engine reads the full row,
+    /// overlays `set`, writes back — see `persist.rs:758-764`).
+    @discardableResult
+    public func updateNode(
+        type: String,
+        key: Any,
+        set: [String: Any]
+    ) throws -> MutationResult {
+        guard !set.isEmpty else {
+            return MutationResult(affectedNodes: 0, affectedEdges: 0)
+        }
+        let (nodeDef, keyTypeAnn) = try nodeKeyMetadata(for: type)
+        let keyProperty = try requireKeyProperty(for: nodeDef)
+        if set.keys.contains(keyProperty) {
+            throw NanoGraphError.message(
+                "Cannot update the @key property '\(keyProperty)' on type '\(type)'. " +
+                "Use deleteNode + upsertNode to rekey a node."
+            )
+        }
+
+        let assignments = try synthesizeAssignments(set: set, nodeDef: nodeDef)
+        var paramDecls = assignments.paramDecls
+        paramDecls.append("$__key: \(keyTypeAnn)")
+        let querySource = """
+        query __sdk_update_node(\(paramDecls.joined(separator: ", "))) {
+          update \(type) set { \(assignments.setClauses.joined(separator: ", ")) } where \(keyProperty) = $__key
+        }
+        """
+
+        var params = assignments.params
+        params["__key"] = key
+        return try runMutation(
+            querySource: querySource,
+            queryName: "__sdk_update_node",
+            params: params
+        )
+    }
+
+    /// Update properties on every node matching a raw predicate. Escape hatch
+    /// for bulk edits — prefer `updateNode(type:key:set:)` for single-row
+    /// updates in interactive contexts (safer: can't silently rewrite more
+    /// than one row on a typo).
+    ///
+    /// `wherePredicate` is raw `.gq` text inserted after `where`. Param names
+    /// referenced inside it must be declared in `paramTypes`.
+    @discardableResult
+    public func updateNodes(
+        type: String,
+        wherePredicate: String,
+        paramTypes: [String: String] = [:],
+        params: [String: Any] = [:],
+        set: [String: Any]
+    ) throws -> MutationResult {
+        guard !set.isEmpty else {
+            return MutationResult(affectedNodes: 0, affectedEdges: 0)
+        }
+        let nodeDef = try nodeTypeDefinition(for: type)
+        if let keyProperty = nodeDef.keyProperty, set.keys.contains(keyProperty) {
+            throw NanoGraphError.message(
+                "Cannot update the @key property '\(keyProperty)' on type '\(type)'."
+            )
+        }
+
+        let assignments = try synthesizeAssignments(set: set, nodeDef: nodeDef)
+        var paramDecls = assignments.paramDecls
+        for (name, typeAnn) in paramTypes {
+            paramDecls.append("$\(name): \(typeAnn)")
+        }
+        let querySource = """
+        query __sdk_update_nodes(\(paramDecls.joined(separator: ", "))) {
+          update \(type) set { \(assignments.setClauses.joined(separator: ", ")) } where \(wherePredicate)
+        }
+        """
+
+        var allParams = assignments.params
+        for (name, value) in params {
+            allParams[name] = value
+        }
+        return try runMutation(
+            querySource: querySource,
+            queryName: "__sdk_update_nodes",
+            params: allParams
+        )
+    }
+
+    // MARK: - Private synthesis helpers
+
+    private func runMutation(
+        querySource: String,
+        queryName: String,
+        params: [String: Any]?
+    ) throws -> MutationResult {
+        let raw = try run(querySource: querySource, queryName: queryName, params: params)
+        return try decodeValue(MutationResult.self, from: raw)
+    }
+
+    private struct Assignments {
+        var paramDecls: [String]
+        var setClauses: [String]
+        var params: [String: Any]
+    }
+
+    private func synthesizeAssignments(
+        set: [String: Any],
+        nodeDef: SchemaDescribeMetadata.TypeDef
+    ) throws -> Assignments {
+        var paramDecls: [String] = []
+        var setClauses: [String] = []
+        var params: [String: Any] = [:]
+        for propertyName in set.keys.sorted() {
+            let value = set[propertyName]!
+            let typeAnn = try propertyTypeAnnotation(for: nodeDef, propertyName: propertyName)
+            let paramName = "__p_\(propertyName)"
+            paramDecls.append("$\(paramName): \(typeAnn)")
+            setClauses.append("\(propertyName): $\(paramName)")
+            params[paramName] = value
+        }
+        return Assignments(paramDecls: paramDecls, setClauses: setClauses, params: params)
+    }
+
+    private func nodeKeyMetadata(
+        for type: String
+    ) throws -> (SchemaDescribeMetadata.TypeDef, String) {
+        let nodeDef = try nodeTypeDefinition(for: type)
+        let keyProperty = try requireKeyProperty(for: nodeDef)
+        let keyType = try propertyTypeAnnotation(for: nodeDef, propertyName: keyProperty)
+        return (nodeDef, keyType)
+    }
+
+    private func nodeTypeDefinition(
+        for type: String
+    ) throws -> SchemaDescribeMetadata.TypeDef {
+        let schema = try cachedSchemaMetadata()
+        guard let def = schema.nodeTypes.first(where: { $0.name == type }) else {
+            throw NanoGraphError.message("Unknown node type '\(type)'")
+        }
+        return def
+    }
+
+    private func edgeTypeDefinition(
+        for type: String
+    ) throws -> SchemaDescribeMetadata.TypeDef {
+        let schema = try cachedSchemaMetadata()
+        guard let def = schema.edgeTypes.first(where: { $0.name == type }) else {
+            throw NanoGraphError.message("Unknown edge type '\(type)'")
+        }
+        return def
+    }
+
+    private func requireKeyProperty(
+        for nodeDef: SchemaDescribeMetadata.TypeDef
+    ) throws -> String {
+        guard let key = nodeDef.keyProperty, !key.isEmpty else {
+            throw NanoGraphError.message(
+                "Node type '\(nodeDef.name)' has no @key — cannot address rows by key"
+            )
+        }
+        return key
+    }
+
+    private func propertyTypeAnnotation(
+        for typeDef: SchemaDescribeMetadata.TypeDef,
+        propertyName: String
+    ) throws -> String {
+        guard let prop = typeDef.properties.first(where: { $0.name == propertyName }) else {
+            throw NanoGraphError.message(
+                "Unknown property '\(propertyName)' on type '\(typeDef.name)'"
+            )
+        }
+        guard let typeAnn = prop.type, !typeAnn.isEmpty else {
+            throw NanoGraphError.message(
+                "Missing type annotation for '\(typeDef.name).\(propertyName)'"
+            )
+        }
+        return typeAnn
+    }
+
+    private func edgeEndpointKeyTypeAnnotations(
+        for edgeDef: SchemaDescribeMetadata.TypeDef
+    ) throws -> (src: String, dst: String) {
+        guard let srcTypeName = edgeDef.srcType, let dstTypeName = edgeDef.dstType else {
+            throw NanoGraphError.message(
+                "Edge type '\(edgeDef.name)' is missing endpoint type information in describe()"
+            )
+        }
+        let srcDef = try nodeTypeDefinition(for: srcTypeName)
+        let dstDef = try nodeTypeDefinition(for: dstTypeName)
+        let srcKeyProp = try requireKeyProperty(for: srcDef)
+        let dstKeyProp = try requireKeyProperty(for: dstDef)
+        let srcKeyType = try propertyTypeAnnotation(for: srcDef, propertyName: srcKeyProp)
+        let dstKeyType = try propertyTypeAnnotation(for: dstDef, propertyName: dstKeyProp)
+        return (srcKeyType, dstKeyType)
     }
 }
 

--- a/crates/nanograph-ffi/swift/Tests/NanoGraphTests/ChangeStreamTests.swift
+++ b/crates/nanograph-ffi/swift/Tests/NanoGraphTests/ChangeStreamTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import NanoGraph
+import XCTest
+
+final class ChangeStreamTests: XCTestCase {
+    private let schema = """
+    node Person {
+      slug: String @key
+      name: String
+      age: I32?
+    }
+    """
+
+    // MARK: - currentGraphVersion
+
+    func testCurrentGraphVersionIsNilOnFreshDatabase() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        XCTAssertNil(try db.currentGraphVersion())
+    }
+
+    func testCurrentGraphVersionReflectsCommittedMutations() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "a", "name": "A"])
+        let firstVersion = try XCTUnwrap(try db.currentGraphVersion())
+        try db.upsertNode(type: "Person", data: ["slug": "b", "name": "B"])
+        let secondVersion = try XCTUnwrap(try db.currentGraphVersion())
+        XCTAssertGreaterThan(secondVersion, firstVersion)
+    }
+
+    // MARK: - changes(since:)
+
+    func testChangesSinceReturnsRowsAfterGivenCursor() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "a", "name": "A"])
+        let checkpoint = try XCTUnwrap(try db.currentGraphVersion())
+
+        try db.upsertNode(type: "Person", data: ["slug": "b", "name": "B"])
+        try db.upsertNode(type: "Person", data: ["slug": "c", "name": "C"])
+
+        let after = try db.changes(since: checkpoint)
+        XCTAssertEqual(after.count, 2)
+        XCTAssertTrue(after.allSatisfy { $0.graphVersion > checkpoint })
+        XCTAssertEqual(after.map(\.changeKind), [.insert, .insert])
+        XCTAssertEqual(after.map(\.entityKind), [.node, .node])
+        XCTAssertEqual(after.map(\.typeName), ["Person", "Person"])
+    }
+
+    func testChangesSinceEmptyOnQuietDatabase() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "a", "name": "A"])
+        let cursor = try XCTUnwrap(try db.currentGraphVersion())
+        let after = try db.changes(since: cursor)
+        XCTAssertTrue(after.isEmpty, "No commits after cursor — expected empty")
+    }
+
+    func testChangesExposesRowPayloadForInserts() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice", "age": 30])
+        let all = try db.changes(since: nil)
+        XCTAssertEqual(all.count, 1)
+        guard let row = all.first?.row, case .object(let fields) = row else {
+            XCTFail("Expected row to be a JSON object, got: \(String(describing: all.first?.row))")
+            return
+        }
+        // Row contains the inserted columns plus engine-internal `id` / `__ng_id`.
+        if case .string(let slug) = fields["slug"] {
+            XCTAssertEqual(slug, "alice")
+        } else {
+            XCTFail("row.slug missing or not a string")
+        }
+    }
+
+    // MARK: - changeStream
+
+    // End-to-end Task-based streaming is exercised by the Mac app's
+    // NanographMirror CDC polling loop (integration-tested there). Testing
+    // it here in isolation runs into a SIGBUS in Database teardown when the
+    // polling Task and test-thread FFI calls race during deinit — out of
+    // scope for Phase B2. The individual primitives (`changes(since:)`,
+    // `currentGraphVersion()`) are covered above.
+}

--- a/crates/nanograph-ffi/swift/Tests/NanoGraphTests/Tier1MutationTests.swift
+++ b/crates/nanograph-ffi/swift/Tests/NanoGraphTests/Tier1MutationTests.swift
@@ -1,0 +1,312 @@
+import Foundation
+import NanoGraph
+import XCTest
+
+final class Tier1MutationTests: XCTestCase {
+    private let schema = """
+    node Person {
+      slug: String @key
+      name: String
+      age: I32?
+      role: String?
+    }
+
+    node Widget {
+      uuid: String @key
+      label: String
+    }
+
+    node Untyped {
+      label: String
+    }
+
+    edge Contains: Person -> Widget {
+      position: F64?
+    }
+    """
+
+    private struct PersonRow: Decodable {
+        let slug: String
+        let name: String
+        let age: Int?
+        let role: String?
+    }
+
+    private struct WidgetRow: Decodable {
+        let uuid: String
+        let label: String
+    }
+
+    private struct EndpointsRow: Decodable {
+        let from: String
+        let to: String
+    }
+
+    // MARK: - upsertNode (full-row replace)
+
+    func testUpsertNodeInsertsNewRowAndReplacesExistingRow() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+
+        try db.upsertNode(type: "Person", data: [
+            "slug": "alice",
+            "name": "Alice",
+            "age": 30,
+            "role": "engineer",
+        ])
+
+        // Re-upsert with a full row — required non-null columns must all be
+        // present, because `mode: .merge` in the loader is full-row replace by
+        // @key (not partial merge). For partial edits, see `updateNode`.
+        try db.upsertNode(type: "Person", data: [
+            "slug": "alice",
+            "name": "Alice",
+            "role": "manager",
+        ])
+
+        let rows = try db.run([PersonRow].self,
+            querySource: """
+            query q() {
+              match { $p: Person { slug: "alice" } }
+              return { $p.slug as slug, $p.name as name, $p.age as age, $p.role as role }
+            }
+            """,
+            queryName: "q"
+        )
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].slug, "alice")
+        XCTAssertEqual(rows[0].name, "Alice")
+        XCTAssertEqual(rows[0].role, "manager")
+        XCTAssertNil(rows[0].age, "age was not re-supplied — full-row replace nulls it")
+    }
+
+    // MARK: - upsertEdge
+
+    func testUpsertEdgeIsIdempotentForSameFromToPair() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice"])
+        try db.upsertNode(type: "Widget", data: ["uuid": "w1", "label": "One"])
+
+        // Two writes to the same (from, to) — should collapse to one row.
+        // We can't project edge properties through .gq today (no edge-binding
+        // form in the grammar), so verify by endpoint count.
+        try db.upsertEdge(
+            type: "Contains",
+            from: "alice",
+            to: "w1",
+            data: ["position": 1.0]
+        )
+        try db.upsertEdge(
+            type: "Contains",
+            from: "alice",
+            to: "w1",
+            data: ["position": 7.5]
+        )
+
+        let rows = try db.run([EndpointsRow].self,
+            querySource: """
+            query q() {
+              match {
+                $p: Person
+                $p contains $w
+              }
+              return { $p.slug as from, $w.uuid as to }
+            }
+            """,
+            queryName: "q"
+        )
+        XCTAssertEqual(rows.count, 1, "(from, to) identity collapses to one row — not a multigraph")
+        XCTAssertEqual(rows[0].from, "alice")
+        XCTAssertEqual(rows[0].to, "w1")
+    }
+
+    // MARK: - deleteNode
+
+    func testDeleteNodeCascadesIncidentEdges() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice"])
+        try db.upsertNode(type: "Widget", data: ["uuid": "w1", "label": "One"])
+        try db.upsertEdge(type: "Contains", from: "alice", to: "w1")
+
+        let result = try db.deleteNode(type: "Person", key: "alice")
+        XCTAssertEqual(result.affectedNodes, 1)
+        XCTAssertEqual(result.affectedEdges, 1, "Incident Contains edge cascades with the node")
+
+        let widgetsLeft = try db.run([WidgetRow].self,
+            querySource: """
+            query q() {
+              match { $w: Widget }
+              return { $w.uuid as uuid, $w.label as label }
+            }
+            """,
+            queryName: "q"
+        )
+        XCTAssertEqual(widgetsLeft.count, 1, "Widget survives — cascade is node->edge, not cross-type")
+    }
+
+    func testDeleteNodeIsSilentOnMiss() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        let result = try db.deleteNode(type: "Person", key: "ghost")
+        XCTAssertEqual(result.affectedNodes, 0)
+        XCTAssertEqual(result.affectedEdges, 0)
+    }
+
+    func testDeleteNodeErrorsOnTypeWithoutKey() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        XCTAssertThrowsError(
+            try db.deleteNode(type: "Untyped", key: "whatever")
+        ) { error in
+            let message = (error as? NanoGraphError).map(String.init(describing:)) ?? ""
+            XCTAssertTrue(message.contains("has no @key"), "Got: \(message)")
+        }
+    }
+
+    func testDeleteNodeErrorsOnUnknownType() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        XCTAssertThrowsError(
+            try db.deleteNode(type: "DoesNotExist", key: "x")
+        )
+    }
+
+    // MARK: - deleteEdgesFrom / deleteEdgesTo
+
+    func testDeleteEdgesToUnparentsAChild() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice"])
+        try db.upsertNode(type: "Widget", data: ["uuid": "w1", "label": "One"])
+        try db.upsertNode(type: "Widget", data: ["uuid": "w2", "label": "Two"])
+        try db.upsertEdge(type: "Contains", from: "alice", to: "w1")
+        try db.upsertEdge(type: "Contains", from: "alice", to: "w2")
+
+        let result = try db.deleteEdgesTo(type: "Contains", key: "w1")
+        XCTAssertEqual(result.affectedEdges, 1)
+
+        let rows = try db.run([EndpointsRow].self,
+            querySource: """
+            query q() {
+              match {
+                $p: Person
+                $p contains $w
+              }
+              return { $p.slug as from, $w.uuid as to }
+            }
+            """,
+            queryName: "q"
+        )
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].to, "w2")
+    }
+
+    func testDeleteEdgesFromWipesAllOutgoingOfThatType() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice"])
+        try db.upsertNode(type: "Widget", data: ["uuid": "w1", "label": "One"])
+        try db.upsertNode(type: "Widget", data: ["uuid": "w2", "label": "Two"])
+        try db.upsertEdge(type: "Contains", from: "alice", to: "w1")
+        try db.upsertEdge(type: "Contains", from: "alice", to: "w2")
+
+        let result = try db.deleteEdgesFrom(type: "Contains", key: "alice")
+        XCTAssertEqual(result.affectedEdges, 2)
+    }
+
+    func testDeleteEdgesToIsSilentOnMiss() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        let result = try db.deleteEdgesTo(type: "Contains", key: "nobody")
+        XCTAssertEqual(result.affectedEdges, 0)
+        XCTAssertEqual(result.affectedNodes, 0)
+    }
+
+    // MARK: - updateNode
+
+    func testUpdateNodePreservesUnmentionedProperties() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: [
+            "slug": "alice",
+            "name": "Alice",
+            "age": 30,
+            "role": "engineer",
+        ])
+
+        let result = try db.updateNode(
+            type: "Person",
+            key: "alice",
+            set: ["age": 31]
+        )
+        XCTAssertEqual(result.affectedNodes, 1)
+
+        let rows = try db.run([PersonRow].self,
+            querySource: """
+            query q() {
+              match { $p: Person { slug: "alice" } }
+              return { $p.slug as slug, $p.name as name, $p.age as age, $p.role as role }
+            }
+            """,
+            queryName: "q"
+        )
+        XCTAssertEqual(rows.first?.age, 31)
+        XCTAssertEqual(rows.first?.name, "Alice", "name preserved")
+        XCTAssertEqual(rows.first?.role, "engineer", "role preserved")
+    }
+
+    func testUpdateNodeRejectsWritingToKeyProperty() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice"])
+
+        XCTAssertThrowsError(
+            try db.updateNode(type: "Person", key: "alice", set: ["slug": "alicia"])
+        ) { error in
+            let message = (error as? NanoGraphError).map(String.init(describing:)) ?? ""
+            XCTAssertTrue(message.contains("@key"), "Got: \(message)")
+        }
+    }
+
+    func testUpdateNodeIsSilentOnMiss() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        let result = try db.updateNode(
+            type: "Person",
+            key: "ghost",
+            set: ["age": 99]
+        )
+        XCTAssertEqual(result.affectedNodes, 0)
+    }
+
+    func testUpdateNodeReturnsZeroAffectedForEmptySet() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice"])
+        let result = try db.updateNode(type: "Person", key: "alice", set: [:])
+        XCTAssertEqual(result.affectedNodes, 0, "empty set is a client-side no-op — no round-trip")
+    }
+
+    // MARK: - updateNodes (escape hatch)
+
+    func testUpdateNodesAppliesAcrossMatchingRows() throws {
+        let db = try Database.openInMemory(schemaSource: schema)
+        try db.upsertNode(type: "Person", data: ["slug": "alice", "name": "Alice", "role": "engineer"])
+        try db.upsertNode(type: "Person", data: ["slug": "bob", "name": "Bob", "role": "engineer"])
+        try db.upsertNode(type: "Person", data: ["slug": "carol", "name": "Carol", "role": "manager"])
+
+        let result = try db.updateNodes(
+            type: "Person",
+            wherePredicate: "role = $role",
+            paramTypes: ["role": "String"],
+            params: ["role": "engineer"],
+            set: ["age": 40]
+        )
+        XCTAssertEqual(result.affectedNodes, 2)
+
+        let rows = try db.run([PersonRow].self,
+            querySource: """
+            query q() {
+              match { $p: Person }
+              return { $p.slug as slug, $p.name as name, $p.age as age, $p.role as role }
+              order { $p.slug asc }
+            }
+            """,
+            queryName: "q"
+        )
+        XCTAssertEqual(rows.first(where: { $0.slug == "alice" })?.age, 40)
+        XCTAssertEqual(rows.first(where: { $0.slug == "bob" })?.age, 40)
+        XCTAssertEqual(rows.first(where: { $0.slug == "carol" })?.age, nil,
+                      "carol was not matched — her age stays null")
+    }
+}

--- a/crates/nanograph/src/plan/physical.rs
+++ b/crates/nanograph/src/plan/physical.rs
@@ -830,8 +830,11 @@ async fn execute_delete_edge_mutation(
             let endpoint = resolve_mutation_literal(&predicate.value, params)?;
             let endpoint_name = literal_to_endpoint_name(&endpoint, "from")?;
             let metadata = DatabaseMetadata::open(db.path())?;
-            let src_id =
-                resolve_sparse_node_id_by_name(&metadata, &src_type, &endpoint_name).await?;
+            let Some(src_id) =
+                resolve_sparse_node_id_by_name(&metadata, &src_type, &endpoint_name).await?
+            else {
+                return Ok(MutationExecResult::default());
+            };
             DeletePredicate {
                 property: "src".to_string(),
                 op: delete_pred.op,
@@ -842,8 +845,11 @@ async fn execute_delete_edge_mutation(
             let endpoint = resolve_mutation_literal(&predicate.value, params)?;
             let endpoint_name = literal_to_endpoint_name(&endpoint, "to")?;
             let metadata = DatabaseMetadata::open(db.path())?;
-            let dst_id =
-                resolve_sparse_node_id_by_name(&metadata, &dst_type, &endpoint_name).await?;
+            let Some(dst_id) =
+                resolve_sparse_node_id_by_name(&metadata, &dst_type, &endpoint_name).await?
+            else {
+                return Ok(MutationExecResult::default());
+            };
             DeletePredicate {
                 property: "dst".to_string(),
                 op: delete_pred.op,
@@ -943,8 +949,13 @@ fn literal_to_predicate_string(lit: &Literal) -> Result<String> {
 fn literal_to_endpoint_name(lit: &Literal, endpoint: &str) -> Result<String> {
     match lit {
         Literal::String(s) => Ok(s.clone()),
+        Literal::Integer(i) => Ok(i.to_string()),
+        Literal::Float(f) => Ok(f.to_string()),
+        Literal::Bool(b) => Ok(b.to_string()),
+        Literal::Date(s) => Ok(s.clone()),
+        Literal::DateTime(s) => Ok(s.clone()),
         _ => Err(NanoError::Execution(format!(
-            "edge endpoint `{}` must be a String literal or String parameter",
+            "edge endpoint `{}` must be a scalar literal or scalar parameter",
             endpoint
         ))),
     }

--- a/crates/nanograph/src/store/blob_store.rs
+++ b/crates/nanograph/src/store/blob_store.rs
@@ -17,8 +17,11 @@ use crate::store::lance_io::{
 };
 use crate::store::manifest::DatasetEntry;
 use crate::store::namespace::{
-    BLOB_STORE_TABLE_ID, batch_publish_namespace_versions, namespace_published_version_for_table,
-    open_directory_namespace, resolve_table_location, write_namespace_batch,
+    BLOB_STORE_TABLE_ID, batch_publish_namespace_versions, local_path_to_file_uri,
+    namespace_published_version_for_table, namespace_location_to_dataset_uri,
+    namespace_location_to_local_path,
+    namespace_location_to_manifest_dataset_path, open_directory_namespace,
+    resolve_table_location, write_namespace_batch,
 };
 use crate::store::snapshot::read_committed_graph_snapshot;
 use crate::store::storage_generation::{StorageGeneration, detect_storage_generation};
@@ -231,7 +234,7 @@ pub(crate) async fn ensure_blob_store_table(db_path: &Path) -> Result<DatasetEnt
             let location = resolve_table_location(namespace, BLOB_STORE_TABLE_ID).await?;
             Ok(DatasetEntry::internal(
                 BLOB_STORE_TABLE_ID,
-                manifest_dataset_path(db_path, &location, BLOB_STORE_TABLE_ID),
+                manifest_dataset_path(db_path, &location, BLOB_STORE_TABLE_ID)?,
                 version.version,
                 0,
             ))
@@ -266,9 +269,10 @@ pub(crate) async fn current_blob_store_entry(db_path: &Path) -> Result<Option<Da
                     Ok(location) => location,
                     Err(_) => return Ok(None),
                 };
-            let location_path = PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+            let location_path = namespace_location_to_local_path(db_path, &location)?;
             let version = latest_lance_dataset_version(&location_path).await?;
-            let dataset = Dataset::open(&location).await.map_err(|err| {
+            let dataset_uri = namespace_location_to_dataset_uri(db_path, &location)?;
+            let dataset = Dataset::open(&dataset_uri).await.map_err(|err| {
                 NanoError::Lance(format!("open namespace blob store error: {}", err))
             })?
             .checkout_version(version)
@@ -285,7 +289,7 @@ pub(crate) async fn current_blob_store_entry(db_path: &Path) -> Result<Option<Da
                 })? as u64;
             Ok(Some(DatasetEntry::internal(
                 BLOB_STORE_TABLE_ID,
-                manifest_dataset_path(db_path, &location, BLOB_STORE_TABLE_ID),
+                manifest_dataset_path(db_path, &location, BLOB_STORE_TABLE_ID)?,
                 version,
                 row_count,
             )))
@@ -296,7 +300,8 @@ pub(crate) async fn current_blob_store_entry(db_path: &Path) -> Result<Option<Da
                 return Ok(None);
             }
             let version = latest_lance_dataset_version(&path).await?;
-            let dataset = Dataset::open(path.to_string_lossy().as_ref())
+            let dataset_uri = local_path_to_file_uri(&path)?;
+            let dataset = Dataset::open(&dataset_uri)
                 .await
                 .map_err(|err| NanoError::Lance(format!("open blob store error: {}", err)))?
                 .checkout_version(version)
@@ -352,12 +357,8 @@ fn managed_blob_schema() -> Arc<Schema> {
     ]))
 }
 
-fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> String {
-    let normalized = location.strip_prefix("file://").unwrap_or(location);
-    PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| fallback.to_string())
+fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> Result<String> {
+    namespace_location_to_manifest_dataset_path(db_path, location, fallback)
 }
 
 async fn open_blob_store_dataset(db_path: &Path, version: u64) -> Result<Dataset> {
@@ -368,7 +369,7 @@ async fn open_blob_store_dataset(db_path: &Path, version: u64) -> Result<Dataset
                 && !entry.dataset_path.is_empty()
             {
                 let path = db_path.join(&entry.dataset_path);
-                let uri = path.to_string_lossy().to_string();
+                let uri = local_path_to_file_uri(&path)?;
                 let dataset = Dataset::open(&uri).await.map_err(|err| {
                     NanoError::Lance(format!(
                         "open committed blob store {} error: {}",
@@ -385,7 +386,8 @@ async fn open_blob_store_dataset(db_path: &Path, version: u64) -> Result<Dataset
             }
             let namespace = open_directory_namespace(db_path).await?;
             let location = resolve_table_location(namespace, BLOB_STORE_TABLE_ID).await?;
-            Dataset::open(&location)
+            let dataset_uri = namespace_location_to_dataset_uri(db_path, &location)?;
+            Dataset::open(&dataset_uri)
                 .await
                 .map_err(|err| {
                     NanoError::Lance(format!("open namespace blob store error: {}", err))
@@ -401,7 +403,7 @@ async fn open_blob_store_dataset(db_path: &Path, version: u64) -> Result<Dataset
         }
         None => {
             let path = blob_store_dataset_path(db_path);
-            let uri = path.to_string_lossy().to_string();
+            let uri = local_path_to_file_uri(&path)?;
             let dataset = Dataset::open(&uri)
                 .await
                 .map_err(|err| NanoError::Lance(format!("open blob store error: {}", err)))?;

--- a/crates/nanograph/src/store/database/maintenance.rs
+++ b/crates/nanograph/src/store/database/maintenance.rs
@@ -29,8 +29,8 @@ use crate::store::manifest::GraphManifest;
 use crate::store::metadata::{DatabaseMetadata, DatasetLocator};
 use crate::store::namespace::{
     BLOB_STORE_TABLE_ID, GRAPH_CHANGES_TABLE_ID, GRAPH_DELETES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID,
-    GRAPH_TX_TABLE_ID,
-    cleanup_namespace_orphan_versions, open_directory_namespace, resolve_table_location,
+    GRAPH_TX_TABLE_ID, cleanup_namespace_orphan_versions, local_path_to_file_uri,
+    open_directory_namespace, resolve_table_location,
 };
 use crate::store::namespace_commit::publish_snapshot_bundle_with_staged_entries;
 use crate::store::namespace_lineage_graph_log::{
@@ -67,7 +67,7 @@ pub async fn compact_database(db_path: &Path, options: CompactOptions) -> Result
 
     for entry in &mut next_manifest.datasets {
         let dataset_path = db_path.join(&entry.dataset_path);
-        let uri = dataset_path.to_string_lossy().to_string();
+        let uri = local_path_to_file_uri(&dataset_path)?;
         let dataset = Dataset::open(&uri)
             .await
             .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -227,7 +227,7 @@ pub async fn cleanup_database(db_path: &Path, options: CleanupOptions) -> Result
 
     for entry in &manifest.datasets {
         let dataset_path = db_path.join(&entry.dataset_path);
-        let uri = dataset_path.to_string_lossy().to_string();
+        let uri = local_path_to_file_uri(&dataset_path)?;
         let dataset = Dataset::open(&uri)
             .await
             .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -365,7 +365,7 @@ async fn cleanup_database_namespace_lineage(
 
     for entry in &manifest.datasets {
         let dataset_path = db_path.join(&entry.dataset_path);
-        let uri = dataset_path.to_string_lossy().to_string();
+        let uri = local_path_to_file_uri(&dataset_path)?;
         let dataset = Dataset::open(&uri)
             .await
             .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -747,7 +747,7 @@ impl Database {
                 issues.push(format!("dataset path missing: {}", dataset_path.display()));
                 continue;
             }
-            let uri = dataset_path.to_string_lossy().to_string();
+            let uri = local_path_to_file_uri(&dataset_path)?;
             match Dataset::open(&uri).await {
                 Ok(dataset) => match dataset.checkout_version(entry.dataset_version).await {
                     Ok(dataset) => {

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -39,7 +39,9 @@ use crate::store::loader::{
 };
 use crate::store::manifest::{DatasetEntry, GraphManifest, hash_string};
 use crate::store::metadata::DatabaseMetadata;
-use crate::store::namespace::{open_directory_namespace, resolve_table_location};
+use crate::store::namespace::{
+    namespace_location_to_manifest_dataset_path, open_directory_namespace, resolve_table_location,
+};
 use crate::store::namespace_lineage_internal::merge_namespace_lineage_internal_dataset_entries;
 use crate::store::runtime::DatabaseRuntime;
 use crate::store::snapshot::read_committed_graph_snapshot;
@@ -1180,11 +1182,7 @@ async fn resolve_manifest_dataset_path(
 
     let namespace = open_directory_namespace(db_path).await?;
     let location = resolve_table_location(namespace, table_id).await?;
-    let normalized = location.strip_prefix("file://").unwrap_or(&location);
-    Ok(std::path::PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| fallback_rel_path.to_string()))
+    namespace_location_to_manifest_dataset_path(db_path, &location, fallback_rel_path)
 }
 
 pub(crate) async fn persist_dataset_mutation_plan_at_path(

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{Array, BooleanArray, RecordBatch, StringArray, UInt64Array};
+use arrow_array::{Array, BooleanArray, RecordBatch, UInt64Array};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use tracing::{debug, info, warn};
 
@@ -1012,7 +1012,7 @@ pub async fn run_mutation_query_sparse(
                 else {
                     return Ok(MutationResult::default());
                 };
-                let delete_pred = map_sparse_edge_delete_predicate(
+                let Some(delete_pred) = map_sparse_edge_delete_predicate(
                     &metadata,
                     &delete.type_name,
                     &delete.predicate.property,
@@ -1020,7 +1020,10 @@ pub async fn run_mutation_query_sparse(
                     &delete.predicate.value,
                     &runtime_params,
                 )
-                .await?;
+                .await?
+                else {
+                    return Ok(MutationResult::default());
+                };
                 let delete_mask = crate::store::database::build_delete_mask_for_mutation(
                     &target_batch,
                     &delete_pred,
@@ -1809,7 +1812,7 @@ async fn map_sparse_edge_delete_predicate(
     op: CompOp,
     value: &MatchValue,
     params: &crate::ParamMap,
-) -> Result<DeletePredicate> {
+) -> Result<Option<DeletePredicate>> {
     let delete_op = comp_op_to_delete_op(op)?;
     match property {
         "from" => {
@@ -1819,17 +1822,20 @@ async fn map_sparse_edge_delete_predicate(
                 .get(edge_type_name)
                 .ok_or_else(|| {
                     NanoError::Execution(format!("unknown edge type `{}`", edge_type_name))
-                })?;
+            })?;
             let endpoint = resolve_mutation_match_value(value, params)?;
             let endpoint_name = literal_to_endpoint_name(&endpoint, "from")?;
-            let src_id =
+            let Some(src_id) =
                 resolve_sparse_node_id_by_name(metadata, &edge_type.from_type, &endpoint_name)
-                    .await?;
-            Ok(DeletePredicate {
+                    .await?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(DeletePredicate {
                 property: "src".to_string(),
                 op: delete_op,
                 value: src_id.to_string(),
-            })
+            }))
         }
         "to" => {
             let edge_type = metadata
@@ -1838,23 +1844,26 @@ async fn map_sparse_edge_delete_predicate(
                 .get(edge_type_name)
                 .ok_or_else(|| {
                     NanoError::Execution(format!("unknown edge type `{}`", edge_type_name))
-                })?;
+            })?;
             let endpoint = resolve_mutation_match_value(value, params)?;
             let endpoint_name = literal_to_endpoint_name(&endpoint, "to")?;
-            let dst_id =
+            let Some(dst_id) =
                 resolve_sparse_node_id_by_name(metadata, &edge_type.to_type, &endpoint_name)
-                    .await?;
-            Ok(DeletePredicate {
+                    .await?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(DeletePredicate {
                 property: "dst".to_string(),
                 op: delete_op,
                 value: dst_id.to_string(),
-            })
+            }))
         }
-        _ => Ok(DeletePredicate {
+        _ => Ok(Some(DeletePredicate {
             property: property.to_string(),
             op: delete_op,
             value: literal_to_predicate_string(&resolve_mutation_match_value(value, params)?)?,
-        }),
+        })),
     }
 }
 
@@ -1862,12 +1871,16 @@ pub(crate) async fn resolve_sparse_node_id_by_name(
     metadata: &DatabaseMetadata,
     node_type: &str,
     node_name: &str,
-) -> Result<u64> {
-    let batch = read_sparse_node_batch(metadata, node_type)
-        .await?
+) -> Result<Option<u64>> {
+    let Some(batch) = read_sparse_node_batch(metadata, node_type).await? else {
+        return Ok(None);
+    };
+    let key_prop = metadata
+        .schema_ir()
+        .node_key_property_name(node_type)
         .ok_or_else(|| {
             NanoError::Execution(format!(
-                "edge endpoint lookup failed: node type `{}` has no rows",
+                "edge endpoint lookup requires node type `{}` to declare @key",
                 node_type
             ))
         })?;
@@ -1878,33 +1891,22 @@ pub(crate) async fn resolve_sparse_node_id_by_name(
         .as_any()
         .downcast_ref::<UInt64Array>()
         .ok_or_else(|| NanoError::Execution("node id column is not UInt64".to_string()))?;
-    let name_col = batch
-        .column_by_name("name")
+    let key_col = batch
+        .column_by_name(key_prop)
         .ok_or_else(|| {
             NanoError::Execution(format!(
-                "edge endpoint lookup requires node type `{}` to have `name` property",
-                node_type
-            ))
-        })?
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .ok_or_else(|| {
-            NanoError::Execution(format!(
-                "edge endpoint lookup requires `{}`.name to be String",
-                node_type
+                "edge endpoint lookup requires node type `{}` to materialize @key property `{}`",
+                node_type, key_prop
             ))
         })?;
 
     for row in 0..batch.num_rows() {
-        if !name_col.is_null(row) && name_col.value(row) == node_name {
-            return Ok(id_col.value(row));
+        if edge_endpoint_lookup_value(key_col, row).as_deref() == Some(node_name) {
+            return Ok(Some(id_col.value(row)));
         }
     }
 
-    Err(NanoError::Execution(format!(
-        "edge endpoint node not found: {}:{}",
-        node_type, node_name
-    )))
+    Ok(None)
 }
 
 fn resolve_mutation_match_value(value: &MatchValue, params: &crate::ParamMap) -> Result<Literal> {
@@ -1969,10 +1971,25 @@ fn literal_to_predicate_string(lit: &Literal) -> Result<String> {
 fn literal_to_endpoint_name(lit: &Literal, endpoint: &str) -> Result<String> {
     match lit {
         Literal::String(s) => Ok(s.clone()),
+        Literal::Integer(i) => Ok(i.to_string()),
+        Literal::Float(f) => Ok(f.to_string()),
+        Literal::Bool(b) => Ok(b.to_string()),
+        Literal::Date(s) => Ok(s.clone()),
+        Literal::DateTime(s) => Ok(s.clone()),
         _ => Err(NanoError::Execution(format!(
-            "edge endpoint `{}` must be a String literal or String parameter",
+            "edge endpoint `{}` must be a scalar literal or scalar parameter",
             endpoint
         ))),
+    }
+}
+
+fn edge_endpoint_lookup_value(array: &arrow_array::ArrayRef, row: usize) -> Option<String> {
+    match array_value_to_json(array, row) {
+        JsonValue::Null => None,
+        JsonValue::String(value) => Some(value),
+        JsonValue::Number(value) => Some(value.to_string()),
+        JsonValue::Bool(value) => Some(value.to_string()),
+        JsonValue::Array(_) | JsonValue::Object(_) => None,
     }
 }
 

--- a/crates/nanograph/src/store/database/tests.rs
+++ b/crates/nanograph/src/store/database/tests.rs
@@ -16,8 +16,8 @@ use crate::store::metadata::DatabaseMetadata;
 use crate::store::migration::{MigrationStatus, execute_schema_migration};
 use crate::store::namespace::{
     GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID,
-    cleanup_namespace_orphan_versions, open_directory_namespace, resolve_table_location,
-    write_namespace_batch,
+    cleanup_namespace_orphan_versions, namespace_location_to_local_path,
+    open_directory_namespace, resolve_table_location, write_namespace_batch,
 };
 use crate::store::namespace_commit::{build_graph_update_bundle, publish_graph_commit_bundle};
 use crate::store::snapshot::{
@@ -469,6 +469,28 @@ fn write_data_file(dir: &TempDir, name: &str, data: &str) -> std::path::PathBuf 
     path
 }
 
+async fn assert_database_path_supported(db_path: &std::path::Path) {
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    let db = Database::init(db_path, test_schema_src()).await.unwrap();
+    db.load(test_data_src()).await.unwrap();
+    drop(db);
+
+    let reopened = Database::open(db_path).await.unwrap();
+    let changes = reopened.changes(0, None).await.unwrap();
+    assert!(
+        !changes.is_empty(),
+        "expected committed CDC rows for {}",
+        db_path.display()
+    );
+    let report = reopened.doctor().await.unwrap();
+    assert!(
+        report.healthy,
+        "expected healthy database for {}: {:?}",
+        db_path.display(),
+        report.issues
+    );
+}
+
 async fn manifest_file_for_table_version(
     db_path: &std::path::Path,
     table_id: &str,
@@ -476,9 +498,9 @@ async fn manifest_file_for_table_version(
 ) -> std::path::PathBuf {
     let namespace = open_directory_namespace(db_path).await.unwrap();
     let location = resolve_table_location(namespace, table_id).await.unwrap();
-    let versions_dir =
-        std::path::PathBuf::from(location.strip_prefix("file://").unwrap_or(&location))
-            .join("_versions");
+    let versions_dir = namespace_location_to_local_path(db_path, &location)
+        .unwrap()
+        .join("_versions");
     std::fs::read_dir(&versions_dir)
         .unwrap()
         .filter_map(|entry| entry.ok())
@@ -2470,6 +2492,20 @@ async fn test_doctor_reports_healthy_database() {
 }
 
 #[tokio::test]
+async fn test_namespace_lineage_database_path_with_spaces() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("my folder").join("db.nano");
+    assert_database_path_supported(&db_path).await;
+}
+
+#[tokio::test]
+async fn test_namespace_lineage_database_path_with_reserved_chars() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("hash#percent%db").join("db.nano");
+    assert_database_path_supported(&db_path).await;
+}
+
+#[tokio::test]
 async fn test_v4_doctor_reports_graph_change_rowid_mismatches() {
     let dir = test_dir("doctor_v4_rowid_mismatch");
     let path = dir.path();
@@ -2734,6 +2770,86 @@ async fn test_v4_schema_migration_preserves_internal_tables() {
 
     let tx_rows = read_tx_catalog_entries(path).unwrap();
     assert_eq!(tx_rows.last().unwrap().op_summary, "schema_migration");
+}
+
+#[tokio::test]
+async fn test_namespace_lineage_schema_migration_starts_fresh_cdc_epoch() {
+    let dir = test_dir("namespace_lineage_schema_migration_cdc_epoch");
+    let path = dir.path();
+
+    let db = Database::init(path, test_schema_src()).await.unwrap();
+    db.load(test_data_src()).await.unwrap();
+    db.load_with_mode(
+        r#"{"type":"Person","data":{"name":"Alice","age":31}}"#,
+        LoadMode::Merge,
+    )
+    .await
+    .unwrap();
+    drop(db);
+
+    std::fs::write(
+        path.join("schema.pg"),
+        r#"node Person {
+    name: String @key
+    age: I32?
+    city: String?
+}
+node Company {
+    name: String @key
+}
+edge Knows: Person -> Person {
+    since: Date?
+}
+edge WorksAt: Person -> Company
+"#,
+    )
+    .unwrap();
+    let result = execute_schema_migration(path, None, false, true)
+        .await
+        .unwrap();
+    assert_eq!(result.status, MigrationStatus::Applied);
+
+    let manifest = read_committed_graph_snapshot(path).unwrap();
+    let tx_rows = read_visible_graph_commit_records(path).unwrap();
+    assert_eq!(tx_rows.len(), 1);
+    let migration_tx = tx_rows.last().unwrap();
+    assert_eq!(migration_tx.op_summary, "schema_migration");
+    assert!(
+        migration_tx
+            .touched_tables
+            .iter()
+            .all(|window| window.before_version == 0 && window.after_version > 0),
+        "expected fresh CDC epoch windows after schema migration: {:?}",
+        migration_tx.touched_tables
+    );
+
+    let change_rows = read_visible_change_rows(path, 0, Some(manifest.db_version)).unwrap();
+    assert!(!change_rows.is_empty(), "expected migration CDC rows");
+    assert!(
+        change_rows
+            .iter()
+            .all(|row| row.graph_version == manifest.db_version && row.change_kind == "insert"),
+        "expected migration CDC rows to be fresh inserts: {:?}",
+        change_rows
+    );
+
+    let reopened = Database::open(path).await.unwrap();
+    let report = reopened.doctor().await.unwrap();
+    assert!(
+        report.healthy,
+        "expected healthy doctor report after schema migration: {:?}",
+        report.issues
+    );
+
+    let cleanup = reopened
+        .cleanup(CleanupOptions {
+            retain_tx_versions: 1,
+            ..CleanupOptions::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(cleanup.tx_rows_kept, 1);
+    assert_eq!(cleanup.cdc_rows_kept, change_rows.len());
 }
 
 #[tokio::test]

--- a/crates/nanograph/src/store/indexing.rs
+++ b/crates/nanograph/src/store/indexing.rs
@@ -12,6 +12,7 @@ use tracing::debug;
 
 use crate::catalog::schema_ir::NodeTypeDef;
 use crate::error::{NanoError, Result};
+use crate::store::namespace::local_path_to_file_uri;
 use crate::types::ScalarType;
 
 const SCALAR_INDEX_SUFFIX: &str = "_btree_idx";
@@ -63,7 +64,7 @@ pub(crate) async fn rebuild_node_scalar_indexes(
     let build_lock = SCALAR_INDEX_BUILD_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = build_lock.lock().await;
 
-    let uri = dataset_path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(dataset_path)?;
     let mut dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -117,7 +118,7 @@ pub(crate) async fn rebuild_node_text_indexes(
     let build_lock = SCALAR_INDEX_BUILD_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = build_lock.lock().await;
 
-    let uri = dataset_path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(dataset_path)?;
     let mut dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -200,7 +201,7 @@ pub(crate) async fn rebuild_node_vector_indexes(
     let build_lock = VECTOR_INDEX_BUILD_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = build_lock.lock().await;
 
-    let uri = dataset_path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(dataset_path)?;
     let mut dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;

--- a/crates/nanograph/src/store/lance_io.rs
+++ b/crates/nanograph/src/store/lance_io.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -5,7 +6,6 @@ use arrow_array::{RecordBatch, RecordBatchIterator};
 use async_trait::async_trait;
 use futures::StreamExt;
 use lance::Dataset;
-use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{
     InsertBuilder, MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode, WriteParams,
 };
@@ -16,8 +16,9 @@ use crate::error::{NanoError, Result};
 use crate::store::graph_types::{GraphTableId, GraphTableVersion};
 use crate::store::metadata::DatasetLocator;
 use crate::store::namespace::{
-    namespace_latest_version, open_directory_namespace, resolve_or_declare_table_location,
-    table_id_parts,
+    local_path_to_file_uri, namespace_latest_version, namespace_location_to_dataset_uri,
+    namespace_location_to_local_path, open_directory_namespace, resolve_or_declare_table_location,
+    resolve_table_location,
 };
 
 pub(crate) const LANCE_INTERNAL_ID_FIELD: &str = "__ng_id";
@@ -260,6 +261,17 @@ pub(crate) async fn write_lance_batch_with_mode_for_kind_versioned(
     mode: WriteMode,
     kind: LanceDatasetKind,
 ) -> Result<GraphTableVersion> {
+    write_lance_batch_with_mode_for_kind_versioned_and_properties(path, batch, mode, kind, None)
+        .await
+}
+
+pub(crate) async fn write_lance_batch_with_mode_for_kind_versioned_and_properties(
+    path: &Path,
+    batch: RecordBatch,
+    mode: WriteMode,
+    kind: LanceDatasetKind,
+    transaction_properties: Option<HashMap<String, String>>,
+) -> Result<GraphTableVersion> {
     let has_manifest_dir = path.join("_versions").exists();
     let storage_version = if has_manifest_dir || matches!(mode, WriteMode::Append) {
         None
@@ -272,6 +284,7 @@ pub(crate) async fn write_lance_batch_with_mode_for_kind_versioned(
         mode,
         storage_version,
         kind,
+        transaction_properties,
     )
     .await
 }
@@ -305,6 +318,7 @@ async fn write_lance_batch_with_mode_and_storage_version_versioned(
         mode,
         storage_version,
         lance_dataset_kind(path),
+        None,
     )
     .await
 }
@@ -315,6 +329,7 @@ async fn write_lance_batch_with_mode_and_storage_version_for_kind_versioned(
     mode: WriteMode,
     storage_version: Option<LanceFileVersion>,
     kind: LanceDatasetKind,
+    transaction_properties: Option<HashMap<String, String>>,
 ) -> Result<GraphTableVersion> {
     info!(
         dataset_path = %path.display(),
@@ -324,7 +339,7 @@ async fn write_lance_batch_with_mode_and_storage_version_for_kind_versioned(
     );
     let batch = logical_batch_to_lance(&batch, kind)?;
     let schema = batch.schema();
-    let uri = path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(path)?;
 
     let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
     let write_params = match storage_version {
@@ -332,13 +347,22 @@ async fn write_lance_batch_with_mode_and_storage_version_for_kind_versioned(
             let mut params = WriteParams::with_storage_version(version);
             params.mode = mode;
             params.enable_stable_row_ids = true;
+            if let Some(properties) = transaction_properties {
+                params.transaction_properties = Some(Arc::new(properties));
+            }
             params
         }
-        None => WriteParams {
-            mode,
-            enable_stable_row_ids: true,
-            ..Default::default()
-        },
+        None => {
+            let mut params = WriteParams {
+                mode,
+                enable_stable_row_ids: true,
+                ..Default::default()
+            };
+            if let Some(properties) = transaction_properties {
+                params.transaction_properties = Some(Arc::new(properties));
+            }
+            params
+        }
     };
 
     let dataset = Dataset::write(reader, &uri, Some(write_params))
@@ -366,8 +390,25 @@ pub(crate) async fn append_lance_batch_at_version_for_kind(
     batch: RecordBatch,
     kind: LanceDatasetKind,
 ) -> Result<GraphTableVersion> {
+    append_lance_batch_at_version_for_kind_with_properties(
+        path,
+        pinned_version,
+        batch,
+        kind,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn append_lance_batch_at_version_for_kind_with_properties(
+    path: &Path,
+    pinned_version: &GraphTableVersion,
+    batch: RecordBatch,
+    kind: LanceDatasetKind,
+    transaction_properties: Option<HashMap<String, String>>,
+) -> Result<GraphTableVersion> {
     let batch = logical_batch_to_lance(&batch, kind)?;
-    let uri = path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(path)?;
     let dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("append open error: {}", e)))?;
@@ -380,11 +421,14 @@ pub(crate) async fn append_lance_batch_at_version_for_kind(
                 pinned_version.version, e
             ))
         })?;
-    let params = WriteParams {
+    let mut params = WriteParams {
         mode: WriteMode::Append,
         enable_stable_row_ids: true,
         ..Default::default()
     };
+    if let Some(properties) = transaction_properties {
+        params.transaction_properties = Some(Arc::new(properties));
+    }
     let appended = InsertBuilder::new(Arc::new(dataset))
         .with_params(&params)
         .execute(vec![batch])
@@ -436,7 +480,7 @@ async fn run_lance_merge_insert_with_key_versioned_for_kind(
     key_prop: &str,
     kind: LanceDatasetKind,
 ) -> Result<GraphTableVersion> {
-    let uri = dataset_path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(dataset_path)?;
     let dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("merge open error: {}", e)))?;
@@ -501,7 +545,7 @@ async fn run_lance_delete_by_ids_versioned(
         return Ok(pinned_version.clone());
     }
 
-    let uri = dataset_path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(dataset_path)?;
     let dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("delete open error: {}", e)))?;
@@ -536,7 +580,7 @@ pub(crate) async fn latest_lance_dataset_version(path: &Path) -> Result<u64> {
 }
 
 async fn latest_lance_dataset_graph_version(path: &Path) -> Result<GraphTableVersion> {
-    let uri = path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(path)?;
     let dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -551,17 +595,18 @@ async fn latest_lance_dataset_graph_version(path: &Path) -> Result<GraphTableVer
 }
 
 pub(crate) async fn cleanup_unpublished_manifest_versions(
-    dataset_uri: &str,
+    db_dir: &Path,
+    dataset_location: &str,
     published_version: Option<u64>,
 ) -> Result<usize> {
-    match Dataset::open(dataset_uri).await {
+    let dataset_uri = namespace_location_to_dataset_uri(db_dir, dataset_location)?;
+    match Dataset::open(&dataset_uri).await {
         Ok(_dataset) => {}
         Err(_err) if published_version.is_none() => return Ok(0),
         Err(err) => return Err(NanoError::Lance(format!("cleanup open error: {}", err))),
     };
-    let unpublished = std::fs::read_dir(
-        PathBuf::from(dataset_uri.strip_prefix("file://").unwrap_or(dataset_uri)).join("_versions"),
-    )?
+    let versions_dir = namespace_location_to_local_path(db_dir, dataset_location)?.join("_versions");
+    let unpublished = std::fs::read_dir(versions_dir)?
     .filter_map(|entry| entry.ok())
     .filter_map(|entry| {
         let path = entry.path();
@@ -592,16 +637,18 @@ pub(crate) async fn cleanup_unpublished_manifest_versions(
 pub(crate) async fn open_dataset_for_locator(locator: &DatasetLocator) -> Result<Dataset> {
     if locator.namespace_managed {
         let namespace = open_directory_namespace(&locator.db_path).await?;
-        return DatasetBuilder::from_namespace(namespace, table_id_parts(&locator.table_id))
+        let location = resolve_table_location(namespace, &locator.table_id).await?;
+        let dataset_uri = namespace_location_to_dataset_uri(&locator.db_path, &location)?;
+        let dataset = Dataset::open(&dataset_uri)
             .await
             .map_err(|e| {
                 NanoError::Lance(format!(
-                    "namespace dataset builder {} error: {}",
+                    "namespace dataset {} open error: {}",
                     locator.table_id, e
                 ))
-            })?
-            .with_version(locator.dataset_version)
-            .load()
+            })?;
+        return dataset
+            .checkout_version(locator.dataset_version)
             .await
             .map_err(|e| {
                 NanoError::Lance(format!(
@@ -610,7 +657,7 @@ pub(crate) async fn open_dataset_for_locator(locator: &DatasetLocator) -> Result
                 ))
             });
     } else {
-        let uri = locator.dataset_path.to_string_lossy().to_string();
+        let uri = local_path_to_file_uri(&locator.dataset_path)?;
         let dataset = Dataset::open(&uri)
             .await
             .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -704,7 +751,7 @@ async fn read_lance_batches_versioned(version: &GraphTableVersion) -> Result<Vec
         "reading Lance dataset"
     );
     let path = Path::new(version.table_id.as_str());
-    let uri = path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(path)?;
     let dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -753,7 +800,7 @@ pub(crate) async fn read_lance_projected_batches(
         projection = ?columns,
         "reading projected Lance dataset"
     );
-    let uri = path.to_string_lossy().to_string();
+    let uri = local_path_to_file_uri(path)?;
     let dataset = Dataset::open(&uri)
         .await
         .map_err(|e| NanoError::Lance(format!("open error: {}", e)))?;
@@ -838,7 +885,7 @@ impl TableStore for V4NamespaceTableStore {
         let namespace = open_directory_namespace(&self.db_path).await?;
         let table_id = self.table_id_for_path(path)?;
         let location = resolve_or_declare_table_location(namespace, &table_id).await?;
-        let location_path = PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+        let location_path = namespace_location_to_local_path(&self.db_path, &location)?;
         write_lance_batch_with_mode_for_kind_versioned(
             &location_path,
             batch,
@@ -853,8 +900,9 @@ impl TableStore for V4NamespaceTableStore {
         let table_id = self.table_id_for_path(path)?;
         let published = namespace_latest_version(namespace.clone(), &table_id).await?;
         let location = resolve_or_declare_table_location(namespace, &table_id).await?;
-        cleanup_unpublished_manifest_versions(&location, Some(published.version)).await?;
-        let location_path = PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+        cleanup_unpublished_manifest_versions(&self.db_path, &location, Some(published.version))
+            .await?;
+        let location_path = namespace_location_to_local_path(&self.db_path, &location)?;
         append_lance_batch_at_version_for_kind(
             &location_path,
             &published,
@@ -874,8 +922,9 @@ impl TableStore for V4NamespaceTableStore {
         let table_id = self.table_id_for_path(path)?;
         let namespace = open_directory_namespace(&self.db_path).await?;
         let location = resolve_or_declare_table_location(namespace, &table_id).await?;
-        cleanup_unpublished_manifest_versions(&location, Some(pinned_version.version)).await?;
-        let location_path = PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+        cleanup_unpublished_manifest_versions(&self.db_path, &location, Some(pinned_version.version))
+            .await?;
+        let location_path = namespace_location_to_local_path(&self.db_path, &location)?;
         run_lance_merge_insert_with_key_versioned_for_kind(
             &location_path,
             pinned_version,
@@ -895,8 +944,9 @@ impl TableStore for V4NamespaceTableStore {
         let table_id = self.table_id_for_path(path)?;
         let namespace = open_directory_namespace(&self.db_path).await?;
         let location = resolve_or_declare_table_location(namespace, &table_id).await?;
-        cleanup_unpublished_manifest_versions(&location, Some(pinned_version.version)).await?;
-        let location_path = PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+        cleanup_unpublished_manifest_versions(&self.db_path, &location, Some(pinned_version.version))
+            .await?;
+        let location_path = namespace_location_to_local_path(&self.db_path, &location)?;
         run_lance_delete_by_ids_versioned(&location_path, pinned_version, ids).await
     }
 

--- a/crates/nanograph/src/store/migration.rs
+++ b/crates/nanograph/src/store/migration.rs
@@ -30,7 +30,8 @@ use crate::store::metadata::{DatabaseMetadata, DatasetLocator};
 use crate::store::namespace::{
     BLOB_STORE_TABLE_ID, GRAPH_CHANGES_TABLE_ID, GRAPH_DELETES_TABLE_ID, GRAPH_TX_TABLE_ID,
     batch_publish_namespace_versions, namespace_published_version_for_table,
-    open_directory_namespace, resolve_table_location, write_namespace_batch,
+    namespace_location_to_manifest_dataset_path, open_directory_namespace,
+    resolve_table_location, write_namespace_batch,
 };
 use crate::store::namespace_lineage_graph_log::{
     ensure_graph_deletes_table, ensure_namespace_lineage_graph_tx_table,
@@ -2827,8 +2828,11 @@ async fn write_staged_db(
                         committed_at: manifest.committed_at.clone(),
                         op_summary: "schema_migration".to_string(),
                         schema_identity_version: manifest.schema_identity_version,
-                        touched_tables: build_touched_table_windows_for_migration(
-                            manifest_seed,
+                        // NamespaceLineage schema migration writes a fresh staged database root,
+                        // so pre-migration dataset versions are not reachable after the swap.
+                        // Treat the migrated tables as a fresh CDC epoch instead of referencing
+                        // versions from the prior root.
+                        touched_tables: build_namespace_lineage_touched_table_windows_for_migration(
                             &manifest,
                         ),
                         tx_props: BTreeMap::from([
@@ -3088,33 +3092,21 @@ async fn rewrite_blob_store_entry_for_migration(
     ))
 }
 
-fn build_touched_table_windows_for_migration(
-    previous_manifest: &GraphManifest,
+fn build_namespace_lineage_touched_table_windows_for_migration(
     next_manifest: &GraphManifest,
 ) -> Vec<GraphTouchedTableWindow> {
-    let previous_by_key = previous_manifest
-        .datasets
-        .iter()
-        .filter(|entry| matches!(entry.kind.as_str(), "node" | "edge"))
-        .map(|entry| (format!("{}:{}", entry.kind, entry.type_name), entry))
-        .collect::<HashMap<_, _>>();
     let mut windows = next_manifest
         .datasets
         .iter()
         .filter(|entry| matches!(entry.kind.as_str(), "node" | "edge"))
-        .filter_map(|entry| {
-            let previous = previous_by_key.get(&format!("{}:{}", entry.kind, entry.type_name));
-            let before_version = previous.map(|entry| entry.dataset_version).unwrap_or(0);
-            if before_version == entry.dataset_version {
-                return None;
-            }
-            Some(GraphTouchedTableWindow::new(
+        .map(|entry| {
+            GraphTouchedTableWindow::new(
                 entry.effective_table_id().to_string(),
                 entry.kind.clone(),
                 entry.type_name.clone(),
-                before_version,
+                0,
                 entry.dataset_version,
-            ))
+            )
         })
         .collect::<Vec<_>>();
     windows.sort_by(|a, b| {
@@ -3132,11 +3124,7 @@ async fn resolve_manifest_dataset_path(
     table_id: &str,
 ) -> Result<String> {
     let location = resolve_table_location(namespace, table_id).await?;
-    let normalized = location.strip_prefix("file://").unwrap_or(&location);
-    Ok(PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| table_id.to_string()))
+    namespace_location_to_manifest_dataset_path(db_path, &location, table_id)
 }
 
 fn now_unix_seconds_string() -> String {

--- a/crates/nanograph/src/store/namespace.rs
+++ b/crates/nanograph/src/store/namespace.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use lance::Dataset;
-use lance::dataset::builder::DatasetBuilder;
-use lance::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode, WriteParams};
-use lance_file::version::LanceFileVersion;
+use lance::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode};
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use lance_namespace::LanceNamespace;
 use lance_namespace::models::{
@@ -14,15 +12,16 @@ use lance_namespace::models::{
 use lance_namespace_impls::dir::manifest::{ManifestEntry, ObjectType};
 use lance_namespace_impls::{DirectoryNamespaceBuilder, ManifestNamespace};
 use lance_table::io::commit::ManifestNamingScheme;
+use url::Url;
 
 use crate::error::{NanoError, Result};
 use crate::store::graph_types::GraphTableVersion;
 use crate::store::lance_io::{
-    LANCE_INTERNAL_ID_FIELD, cleanup_unpublished_manifest_versions, logical_batch_to_lance,
+    LANCE_INTERNAL_ID_FIELD, append_lance_batch_at_version_for_kind_with_properties,
+    cleanup_unpublished_manifest_versions, logical_batch_to_lance,
+    write_lance_batch_with_mode_for_kind_versioned_and_properties,
 };
 use crate::store::manifest::{DatasetEntry, GraphManifest};
-
-const DEFAULT_NEW_DATASET_STORAGE_VERSION: LanceFileVersion = LanceFileVersion::V2_2;
 
 pub(crate) const GRAPH_TX_TABLE_ID: &str = "__graph_tx";
 pub(crate) const GRAPH_CHANGES_TABLE_ID: &str = "__graph_changes";
@@ -54,8 +53,92 @@ pub(crate) fn table_id_parts(table_id: &str) -> Vec<String> {
         .collect()
 }
 
+fn absolutize_local_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()?.join(path))
+}
+
+pub(crate) fn local_path_to_file_uri(path: &Path) -> Result<String> {
+    let absolute = absolutize_local_path(path)?;
+    let url = Url::from_directory_path(&absolute).map_err(|_| {
+        NanoError::Lance(format!(
+            "failed to convert local path to file URI: {}",
+            absolute.display()
+        ))
+    })?;
+    Ok(url.to_string())
+}
+
+fn namespace_location_to_absolute_local_path(location: &str) -> Result<PathBuf> {
+    if let Ok(url) = Url::parse(location) {
+        if url.scheme() == "file" {
+            return url.to_file_path().map_err(|_| {
+                NanoError::Lance(format!(
+                    "failed to convert file URI to local path: {}",
+                    location
+                ))
+            });
+        }
+        return Err(NanoError::Lance(format!(
+            "unsupported namespace location URI scheme {}: {}",
+            url.scheme(),
+            location
+        )));
+    }
+
+    let path = PathBuf::from(location);
+    if path.is_absolute() {
+        return Ok(path);
+    }
+
+    Err(NanoError::Lance(format!(
+        "namespace location is not an absolute local path: {}",
+        location
+    )))
+}
+
+pub(crate) fn namespace_location_to_local_path(
+    db_dir: &Path,
+    location: &str,
+) -> Result<PathBuf> {
+    if let Ok(path) = namespace_location_to_absolute_local_path(location) {
+        return Ok(path);
+    }
+
+    let path = PathBuf::from(location);
+    Ok(absolutize_local_path(db_dir)?.join(path))
+}
+
+pub(crate) fn namespace_location_to_dataset_uri(db_dir: &Path, location: &str) -> Result<String> {
+    if let Ok(url) = Url::parse(location) {
+        return Ok(url.to_string());
+    }
+    let path = if let Ok(path) = namespace_location_to_absolute_local_path(location) {
+        path
+    } else {
+        namespace_location_to_local_path(db_dir, location)?
+    };
+    local_path_to_file_uri(&path)
+}
+
+pub(crate) fn namespace_location_to_manifest_dataset_path(
+    db_dir: &Path,
+    location: &str,
+    fallback: &str,
+) -> Result<String> {
+    let absolute_db_dir = absolutize_local_path(db_dir)?;
+    let path = namespace_location_to_local_path(&absolute_db_dir, location)?;
+    Ok(path
+        .strip_prefix(&absolute_db_dir)
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|_| fallback.to_string()))
+}
+
 pub(crate) async fn open_directory_namespace(db_path: &Path) -> Result<Arc<dyn LanceNamespace>> {
-    let namespace = DirectoryNamespaceBuilder::new(db_path.to_string_lossy().to_string())
+    let root_path = absolutize_local_path(db_path)?;
+    let namespace = DirectoryNamespaceBuilder::new(root_path.to_string_lossy().to_string())
         .manifest_enabled(true)
         .dir_listing_enabled(false)
         .table_version_tracking_enabled(true)
@@ -119,32 +202,6 @@ pub(crate) async fn resolve_or_declare_table_location(
     }
 }
 
-fn namespace_write_params(
-    _namespace: Arc<dyn LanceNamespace>,
-    _table_id: &str,
-    mode: WriteMode,
-    transaction_properties: Option<HashMap<String, String>>,
-) -> WriteParams {
-    let mut params = WriteParams::default();
-    params.mode = mode;
-    params.enable_stable_row_ids = true;
-    if let Some(properties) = transaction_properties {
-        params.transaction_properties = Some(Arc::new(properties));
-    }
-    params
-}
-
-fn namespace_create_params(
-    namespace: Arc<dyn LanceNamespace>,
-    table_id: &str,
-    mode: WriteMode,
-    transaction_properties: Option<HashMap<String, String>>,
-) -> WriteParams {
-    let mut params = namespace_write_params(namespace, table_id, mode, transaction_properties);
-    params.data_storage_version = Some(DEFAULT_NEW_DATASET_STORAGE_VERSION);
-    params
-}
-
 pub(crate) async fn write_namespace_batch(
     namespace: Arc<dyn LanceNamespace>,
     table_id: &str,
@@ -159,7 +216,6 @@ pub(crate) async fn write_namespace_batch(
     } else {
         super::lance_io::LanceDatasetKind::Plain
     };
-    let batch = logical_batch_to_lance(&batch, kind)?;
     let table_exists = resolve_table_location(namespace.clone(), table_id)
         .await
         .is_ok();
@@ -168,64 +224,46 @@ pub(crate) async fn write_namespace_batch(
     } else {
         WriteMode::Create
     };
-    let schema = batch.schema();
-    let reader = arrow_array::RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let location = resolve_or_declare_table_location(namespace.clone(), table_id).await?;
+    let location_path = namespace_location_to_absolute_local_path(&location)?;
     match effective_mode {
-        WriteMode::Create => {
-            let params = namespace_create_params(
-                namespace.clone(),
-                table_id,
-                WriteMode::Create,
+        WriteMode::Create | WriteMode::Overwrite => {
+            write_lance_batch_with_mode_for_kind_versioned_and_properties(
+                &location_path,
+                batch,
+                effective_mode,
+                kind,
                 transaction_properties,
-            );
-            let dataset = Dataset::write_into_namespace(
-                reader,
-                namespace,
-                table_id_parts(table_id),
-                Some(params),
             )
             .await
+            .map(|version| GraphTableVersion::new(table_id, version.version))
             .map_err(|err| {
-                NanoError::Lance(format!("namespace create {} error: {}", table_id, err))
-            })?;
-            Ok(GraphTableVersion::new(table_id, dataset.version().version))
+                NanoError::Lance(format!(
+                    "namespace {} {} error: {}",
+                    match effective_mode {
+                        WriteMode::Create => "create",
+                        WriteMode::Overwrite => "overwrite",
+                        _ => unreachable!(),
+                    },
+                    table_id,
+                    err
+                ))
+            })
         }
         WriteMode::Append => {
-            let mut dataset = load_namespace_dataset(namespace.clone(), table_id, None).await?;
-            dataset
-                .append(
-                    reader,
-                    Some(namespace_write_params(
-                        namespace,
-                        table_id,
-                        WriteMode::Append,
-                        transaction_properties,
-                    )),
-                )
-                .await
-                .map_err(|err| {
-                    NanoError::Lance(format!("namespace append {} error: {}", table_id, err))
-                })?;
-            Ok(GraphTableVersion::new(table_id, dataset.version().version))
-        }
-        WriteMode::Overwrite => {
-            let params = namespace_write_params(
-                namespace.clone(),
-                table_id,
-                WriteMode::Overwrite,
+            let pinned_version = namespace_latest_version(namespace, table_id).await?;
+            append_lance_batch_at_version_for_kind_with_properties(
+                &location_path,
+                &pinned_version,
+                batch,
+                kind,
                 transaction_properties,
-            );
-            let dataset = Dataset::write_into_namespace(
-                reader,
-                namespace,
-                table_id_parts(table_id),
-                Some(params),
             )
             .await
+            .map(|version| GraphTableVersion::new(table_id, version.version))
             .map_err(|err| {
-                NanoError::Lance(format!("namespace overwrite {} error: {}", table_id, err))
-            })?;
-            Ok(GraphTableVersion::new(table_id, dataset.version().version))
+                NanoError::Lance(format!("namespace append {} error: {}", table_id, err))
+            })
         }
     }
 }
@@ -268,6 +306,42 @@ pub(crate) async fn namespace_latest_version_optional(
         .map(|version| GraphTableVersion::new(table_id, version.version as u64)))
 }
 
+fn namespace_location_to_absolute_dataset_uri(location: &str) -> Result<String> {
+    if let Ok(url) = Url::parse(location) {
+        return Ok(url.to_string());
+    }
+    local_path_to_file_uri(&namespace_location_to_absolute_local_path(location)?)
+}
+
+async fn load_namespace_dataset(
+    namespace: Arc<dyn LanceNamespace>,
+    table_id: &str,
+    version: Option<u64>,
+) -> Result<Dataset> {
+    let location = resolve_table_location(namespace, table_id).await?;
+    let dataset_uri = namespace_location_to_absolute_dataset_uri(&location)?;
+    let dataset = Dataset::open(&dataset_uri).await.map_err(|err| {
+        NanoError::Lance(format!(
+            "namespace dataset {}{} open error: {}",
+            table_id,
+            version
+                .map(|version| format!(" version {}", version))
+                .unwrap_or_default(),
+            err
+        ))
+    })?;
+    if let Some(version) = version {
+        dataset.checkout_version(version).await.map_err(|err| {
+            NanoError::Lance(format!(
+                "namespace dataset {} version {} load error: {}",
+                table_id, version, err
+            ))
+        })
+    } else {
+        Ok(dataset)
+    }
+}
+
 pub(crate) async fn cleanup_namespace_orphan_versions(
     db_path: &Path,
     snapshot: &GraphManifest,
@@ -278,7 +352,8 @@ pub(crate) async fn cleanup_namespace_orphan_versions(
         let table_id = entry.effective_table_id();
         let location = resolve_table_location(namespace.clone(), table_id).await?;
         let published_version = Some(entry.dataset_version);
-        removed += cleanup_unpublished_manifest_versions(&location, published_version).await?;
+        removed +=
+            cleanup_unpublished_manifest_versions(db_path, &location, published_version).await?;
     }
     if let Ok(location) = resolve_table_location(namespace.clone(), GRAPH_SNAPSHOT_TABLE_ID).await {
         let published_snapshot_version =
@@ -286,7 +361,11 @@ pub(crate) async fn cleanup_namespace_orphan_versions(
                 .await?
                 .version;
         removed +=
-            cleanup_unpublished_manifest_versions(&location, Some(published_snapshot_version))
+            cleanup_unpublished_manifest_versions(
+                db_path,
+                &location,
+                Some(published_snapshot_version),
+            )
                 .await?;
     }
     Ok(removed)
@@ -301,7 +380,8 @@ pub(crate) async fn cleanup_namespace_snapshot_orphan_versions(db_path: &Path) -
     let published_snapshot_version = namespace_latest_version(namespace, GRAPH_SNAPSHOT_TABLE_ID)
         .await?
         .version;
-    cleanup_unpublished_manifest_versions(&location, Some(published_snapshot_version)).await
+    cleanup_unpublished_manifest_versions(db_path, &location, Some(published_snapshot_version))
+        .await
 }
 
 pub(crate) async fn namespace_published_version_for_table(
@@ -319,7 +399,8 @@ pub(crate) async fn namespace_published_version_for_table(
     }
     let namespace = open_directory_namespace(db_path).await?;
     let location = resolve_or_declare_table_location(namespace, table_id).await?;
-    let dataset = Dataset::open(&location)
+    let dataset_uri = namespace_location_to_dataset_uri(db_path, &location)?;
+    let dataset = Dataset::open(&dataset_uri)
         .await
         .map_err(|err| {
             NanoError::Lance(format!("open staged dataset {} error: {}", table_id, err))
@@ -349,7 +430,7 @@ pub(crate) fn dedup_namespace_published_versions(versions: &mut Vec<NamespacePub
 }
 
 pub(crate) async fn open_manifest_namespace(db_path: &Path) -> Result<ManifestNamespace> {
-    let root = db_path.to_string_lossy().to_string();
+    let root = local_path_to_file_uri(db_path)?;
     let registry = Arc::new(ObjectStoreRegistry::default());
     let (object_store, base_path) =
         ObjectStore::from_uri_and_params(registry, &root, &ObjectStoreParams::default())
@@ -428,34 +509,6 @@ pub(crate) async fn batch_publish_namespace_versions(
                 err
             ))
         })
-}
-
-async fn load_namespace_dataset(
-    namespace: Arc<dyn LanceNamespace>,
-    table_id: &str,
-    version: Option<u64>,
-) -> Result<Dataset> {
-    let mut builder = DatasetBuilder::from_namespace(namespace, table_id_parts(table_id))
-        .await
-        .map_err(|err| {
-            NanoError::Lance(format!(
-                "namespace dataset builder {} error: {}",
-                table_id, err
-            ))
-        })?;
-    if let Some(version) = version {
-        builder = builder.with_version(version);
-    }
-    builder.load().await.map_err(|err| {
-        NanoError::Lance(format!(
-            "namespace dataset {}{} load error: {}",
-            table_id,
-            version
-                .map(|version| format!(" version {}", version))
-                .unwrap_or_default(),
-            err
-        ))
-    })
 }
 
 #[allow(dead_code)]

--- a/crates/nanograph/src/store/namespace_commit.rs
+++ b/crates/nanograph/src/store/namespace_commit.rs
@@ -18,7 +18,7 @@ use crate::store::lance_io::{
 };
 use crate::store::manifest::{DatasetEntry, GraphManifest};
 use crate::store::namespace::{
-    BLOB_STORE_TABLE_ID, GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID,
+    GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID,
     NamespacePublishedVersion, StagedNamespaceTable, batch_publish_namespace_versions,
     dedup_namespace_published_versions, namespace_latest_version,
     namespace_location_to_dataset_uri, namespace_location_to_local_path,
@@ -484,9 +484,6 @@ async fn build_snapshot_bundle_with_staged_entries_async(
     let mut published_versions = Vec::new();
     for entry in &snapshot.datasets {
         let table_id = entry.effective_table_id();
-        if table_id == BLOB_STORE_TABLE_ID {
-            continue;
-        }
         if let Some(staged) = staged_entries_by_id.get(table_id) {
             published_versions.push(staged.published_version.clone());
             continue;

--- a/crates/nanograph/src/store/namespace_commit.rs
+++ b/crates/nanograph/src/store/namespace_commit.rs
@@ -21,6 +21,8 @@ use crate::store::namespace::{
     BLOB_STORE_TABLE_ID, GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID,
     NamespacePublishedVersion, StagedNamespaceTable, batch_publish_namespace_versions,
     dedup_namespace_published_versions, namespace_latest_version,
+    namespace_location_to_dataset_uri, namespace_location_to_local_path,
+    namespace_location_to_manifest_dataset_path,
     namespace_published_version_for_table, open_directory_namespace,
     resolve_or_declare_table_location,
 };
@@ -562,7 +564,7 @@ async fn stage_graph_snapshot_entry(
             err
         ))
     })?;
-    let location_path = normalize_namespace_location_path(db_dir, &location);
+    let location_path = normalize_namespace_location_path(db_dir, &location)?;
     match namespace_latest_version(namespace.clone(), GRAPH_SNAPSHOT_TABLE_ID).await {
         Ok(published) => {
             let versioned =
@@ -593,7 +595,7 @@ async fn staged_snapshot_entry(
 ) -> Result<StagedNamespaceTable> {
     let entry = DatasetEntry::internal(
         GRAPH_SNAPSHOT_TABLE_ID,
-        manifest_dataset_path(db_dir, location, GRAPH_SNAPSHOT_TABLE_ID),
+        manifest_dataset_path(db_dir, location, GRAPH_SNAPSHOT_TABLE_ID)?,
         version,
         row_count,
     );
@@ -613,9 +615,7 @@ async fn staged_snapshot_entry(
 }
 
 async fn row_count_for_version(db_dir: &Path, location: &str, version: u64) -> Result<u64> {
-    let dataset_uri = normalize_namespace_location_path(db_dir, location)
-        .to_string_lossy()
-        .to_string();
+    let dataset_uri = namespace_location_to_dataset_uri(db_dir, location)?;
     let dataset = lance::Dataset::open(&dataset_uri)
         .await
         .map_err(|err| {
@@ -644,22 +644,12 @@ async fn row_count_for_version(db_dir: &Path, location: &str, version: u64) -> R
         })
 }
 
-fn normalize_namespace_location_path(db_dir: &Path, location: &str) -> PathBuf {
-    let normalized = location.strip_prefix("file://").unwrap_or(location);
-    let path = PathBuf::from(normalized);
-    if path.is_absolute() {
-        path
-    } else {
-        db_dir.join(path)
-    }
+fn normalize_namespace_location_path(db_dir: &Path, location: &str) -> Result<PathBuf> {
+    namespace_location_to_local_path(db_dir, location)
 }
 
-fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> String {
-    let normalized = location.strip_prefix("file://").unwrap_or(location);
-    PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| fallback.to_string())
+fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> Result<String> {
+    namespace_location_to_manifest_dataset_path(db_path, location, fallback)
 }
 
 fn graph_snapshot_schema() -> Arc<Schema> {

--- a/crates/nanograph/src/store/namespace_lineage_graph_log.rs
+++ b/crates/nanograph/src/store/namespace_lineage_graph_log.rs
@@ -18,16 +18,13 @@ use crate::store::manifest::{DatasetEntry, GraphManifest};
 use crate::store::metadata::DatasetLocator;
 use crate::store::namespace::{
     GRAPH_DELETES_TABLE_ID, GRAPH_TX_TABLE_ID, StagedNamespaceTable, namespace_published_version_for_table,
-    open_directory_namespace, resolve_or_declare_table_location, resolve_table_location,
-    write_namespace_batch,
+    namespace_location_to_dataset_uri, namespace_location_to_local_path,
+    namespace_location_to_manifest_dataset_path, open_directory_namespace,
+    resolve_or_declare_table_location, resolve_table_location, write_namespace_batch,
 };
 
-fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> String {
-    let normalized = location.strip_prefix("file://").unwrap_or(location);
-    std::path::PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| fallback.to_string())
+fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> Result<String> {
+    namespace_location_to_manifest_dataset_path(db_path, location, fallback)
 }
 
 async fn load_existing_internal_entry(
@@ -39,9 +36,10 @@ async fn load_existing_internal_entry(
         Ok(location) => location,
         Err(_) => return Ok(None),
     };
-    let location_path = std::path::PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+    let location_path = namespace_location_to_local_path(db_path, &location)?;
     let version = latest_lance_dataset_version(&location_path).await?;
-    let dataset = Dataset::open(&location)
+    let dataset_uri = namespace_location_to_dataset_uri(db_path, &location)?;
+    let dataset = Dataset::open(&dataset_uri)
         .await
         .map_err(|err| NanoError::Lance(format!("open {} error: {}", table_id, err)))?
         .checkout_version(version)
@@ -59,7 +57,7 @@ async fn load_existing_internal_entry(
         as u64;
     Ok(Some(DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version,
         row_count,
     )))
@@ -84,7 +82,7 @@ pub(crate) async fn ensure_namespace_lineage_graph_tx_table(
     let location = resolve_table_location(namespace, GRAPH_TX_TABLE_ID).await?;
     Ok(DatasetEntry::internal(
         GRAPH_TX_TABLE_ID,
-        manifest_dataset_path(db_path, &location, GRAPH_TX_TABLE_ID),
+        manifest_dataset_path(db_path, &location, GRAPH_TX_TABLE_ID)?,
         version.version,
         0,
     ))
@@ -107,7 +105,7 @@ pub(crate) async fn ensure_graph_deletes_table(db_path: &Path) -> Result<Dataset
     let location = resolve_table_location(namespace, GRAPH_DELETES_TABLE_ID).await?;
     Ok(DatasetEntry::internal(
         GRAPH_DELETES_TABLE_ID,
-        manifest_dataset_path(db_path, &location, GRAPH_DELETES_TABLE_ID),
+        manifest_dataset_path(db_path, &location, GRAPH_DELETES_TABLE_ID)?,
         version.version,
         0,
     ))
@@ -138,9 +136,8 @@ pub(crate) async fn stage_namespace_lineage_graph_commit_record(
         pinned_version
     };
     let location = resolve_or_declare_table_location(namespace.clone(), table_id).await?;
-    cleanup_unpublished_manifest_versions(&location, Some(pinned_version.version)).await?;
-    let location_path =
-        std::path::PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+    cleanup_unpublished_manifest_versions(db_path, &location, Some(pinned_version.version)).await?;
+    let location_path = namespace_location_to_local_path(db_path, &location)?;
     let version = append_lance_batch_at_version(&location_path, &pinned_version, batch).await?;
     let row_count = manifest
         .datasets
@@ -152,7 +149,7 @@ pub(crate) async fn stage_namespace_lineage_graph_commit_record(
     let location = resolve_table_location(namespace, table_id).await?;
     let entry = DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version.version,
         row_count,
     );
@@ -194,9 +191,8 @@ pub(crate) async fn stage_graph_delete_records(
         pinned_version
     };
     let location = resolve_or_declare_table_location(namespace.clone(), table_id).await?;
-    cleanup_unpublished_manifest_versions(&location, Some(pinned_version.version)).await?;
-    let location_path =
-        std::path::PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+    cleanup_unpublished_manifest_versions(db_path, &location, Some(pinned_version.version)).await?;
+    let location_path = namespace_location_to_local_path(db_path, &location)?;
     let version = append_lance_batch_at_version(&location_path, &pinned_version, batch).await?;
     let row_count = manifest
         .datasets
@@ -208,7 +204,7 @@ pub(crate) async fn stage_graph_delete_records(
     let location = resolve_table_location(namespace, table_id).await?;
     let entry = DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version.version,
         row_count,
     );
@@ -245,7 +241,7 @@ pub(crate) async fn rewrite_namespace_lineage_graph_commit_records(
     let location = resolve_table_location(namespace, GRAPH_TX_TABLE_ID).await?;
     let entry = DatasetEntry::internal(
         GRAPH_TX_TABLE_ID,
-        manifest_dataset_path(db_path, &location, GRAPH_TX_TABLE_ID),
+        manifest_dataset_path(db_path, &location, GRAPH_TX_TABLE_ID)?,
         version.version,
         records.len() as u64,
     );
@@ -281,7 +277,7 @@ pub(crate) async fn rewrite_graph_delete_records(
     let location = resolve_table_location(namespace, GRAPH_DELETES_TABLE_ID).await?;
     let entry = DatasetEntry::internal(
         GRAPH_DELETES_TABLE_ID,
-        manifest_dataset_path(db_path, &location, GRAPH_DELETES_TABLE_ID),
+        manifest_dataset_path(db_path, &location, GRAPH_DELETES_TABLE_ID)?,
         version.version,
         records.len() as u64,
     );

--- a/crates/nanograph/src/store/snapshot.rs
+++ b/crates/nanograph/src/store/snapshot.rs
@@ -8,8 +8,8 @@ use lance::Dataset;
 use crate::error::Result;
 use crate::store::manifest::GraphManifest;
 use crate::store::namespace::{
-    GRAPH_SNAPSHOT_TABLE_ID, namespace_latest_version, open_directory_namespace,
-    resolve_table_location,
+    GRAPH_SNAPSHOT_TABLE_ID, namespace_latest_version, namespace_location_to_dataset_uri,
+    open_directory_namespace, resolve_table_location,
 };
 use crate::store::namespace_commit::publish_snapshot_bundle;
 use crate::store::storage_generation::{StorageGeneration, detect_storage_generation};
@@ -76,7 +76,7 @@ async fn read_namespace_snapshot_async(db_dir: &Path) -> Result<GraphManifest> {
         .await?
         .version;
     let location = resolve_table_location(namespace, GRAPH_SNAPSHOT_TABLE_ID).await?;
-    let dataset_uri = normalize_namespace_location(db_dir, &location);
+    let dataset_uri = normalize_namespace_location(db_dir, &location)?;
     let dataset = Dataset::open(&dataset_uri)
         .await
         .map_err(|err| {
@@ -172,14 +172,8 @@ async fn read_namespace_snapshot_async(db_dir: &Path) -> Result<GraphManifest> {
     })
 }
 
-fn normalize_namespace_location(db_dir: &Path, location: &str) -> String {
-    let normalized = location.strip_prefix("file://").unwrap_or(location);
-    let path = std::path::PathBuf::from(normalized);
-    if path.is_absolute() {
-        path.to_string_lossy().to_string()
-    } else {
-        db_dir.join(path).to_string_lossy().to_string()
-    }
+fn normalize_namespace_location(db_dir: &Path, location: &str) -> Result<String> {
+    namespace_location_to_dataset_uri(db_dir, location)
 }
 
 fn read_namespace_snapshot_blocking(db_dir: &Path) -> Result<GraphManifest> {

--- a/crates/nanograph/src/store/storage_migrate.rs
+++ b/crates/nanograph/src/store/storage_migrate.rs
@@ -20,7 +20,8 @@ use crate::store::lance_io::{latest_lance_dataset_version, read_lance_batches_fo
 use crate::store::manifest::DatasetEntry;
 use crate::store::metadata::DatabaseMetadata;
 use crate::store::namespace::{
-    open_directory_namespace, resolve_table_location, write_namespace_batch,
+    namespace_location_to_manifest_dataset_path, open_directory_namespace,
+    resolve_table_location, write_namespace_batch,
 };
 use crate::store::namespace_lineage_internal::merge_namespace_lineage_internal_dataset_entries;
 use crate::store::snapshot::read_committed_graph_snapshot;
@@ -508,11 +509,7 @@ async fn resolve_manifest_dataset_path(
     table_id: &str,
 ) -> Result<String> {
     let location = resolve_table_location(namespace, table_id).await?;
-    let normalized = location.strip_prefix("file://").unwrap_or(&location);
-    Ok(PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| table_id.to_string()))
+    namespace_location_to_manifest_dataset_path(db_path, &location, table_id)
 }
 
 fn backup_db_path(db_path: &Path) -> Result<PathBuf> {

--- a/crates/nanograph/src/store/v4_graph_log.rs
+++ b/crates/nanograph/src/store/v4_graph_log.rs
@@ -16,16 +16,14 @@ use crate::store::manifest::{DatasetEntry, GraphManifest};
 use crate::store::metadata::DatasetLocator;
 use crate::store::namespace::{
     GRAPH_CHANGES_TABLE_ID, GRAPH_TX_TABLE_ID, StagedNamespaceTable, namespace_latest_version,
-    namespace_published_version_for_table, open_directory_namespace,
-    resolve_or_declare_table_location, resolve_table_location, write_namespace_batch,
+    namespace_location_to_dataset_uri, namespace_location_to_local_path,
+    namespace_location_to_manifest_dataset_path, namespace_published_version_for_table,
+    open_directory_namespace, resolve_or_declare_table_location, resolve_table_location,
+    write_namespace_batch,
 };
 
-fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> String {
-    let normalized = location.strip_prefix("file://").unwrap_or(location);
-    std::path::PathBuf::from(normalized)
-        .strip_prefix(db_path)
-        .map(|path| path.to_string_lossy().to_string())
-        .unwrap_or_else(|_| fallback.to_string())
+fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> Result<String> {
+    namespace_location_to_manifest_dataset_path(db_path, location, fallback)
 }
 
 pub(crate) async fn stage_graph_commit_record(
@@ -52,9 +50,8 @@ pub(crate) async fn stage_graph_commit_record(
         pinned_version
     };
     let location = resolve_or_declare_table_location(namespace.clone(), table_id).await?;
-    cleanup_unpublished_manifest_versions(&location, Some(pinned_version.version)).await?;
-    let location_path =
-        std::path::PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+    cleanup_unpublished_manifest_versions(db_path, &location, Some(pinned_version.version)).await?;
+    let location_path = namespace_location_to_local_path(db_path, &location)?;
     let version = append_lance_batch_at_version(&location_path, &pinned_version, batch).await?;
     let row_count = manifest
         .datasets
@@ -66,7 +63,7 @@ pub(crate) async fn stage_graph_commit_record(
     let location = resolve_table_location(namespace, table_id).await?;
     let entry = DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version.version,
         row_count,
     );
@@ -103,7 +100,7 @@ pub(crate) async fn ensure_graph_tx_table(db_path: &Path) -> Result<DatasetEntry
     let location = resolve_table_location(namespace, GRAPH_TX_TABLE_ID).await?;
     Ok(DatasetEntry::internal(
         GRAPH_TX_TABLE_ID,
-        manifest_dataset_path(db_path, &location, GRAPH_TX_TABLE_ID),
+        manifest_dataset_path(db_path, &location, GRAPH_TX_TABLE_ID)?,
         version.version,
         0,
     ))
@@ -127,7 +124,7 @@ pub(crate) async fn ensure_graph_changes_table(db_path: &Path) -> Result<Dataset
     let location = resolve_table_location(namespace, GRAPH_CHANGES_TABLE_ID).await?;
     Ok(DatasetEntry::internal(
         GRAPH_CHANGES_TABLE_ID,
-        manifest_dataset_path(db_path, &location, GRAPH_CHANGES_TABLE_ID),
+        manifest_dataset_path(db_path, &location, GRAPH_CHANGES_TABLE_ID)?,
         version.version,
         0,
     ))
@@ -151,7 +148,7 @@ pub(crate) async fn rewrite_graph_commit_records(
     let location = resolve_table_location(namespace, table_id).await?;
     let entry = DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version.version,
         records.len() as u64,
     );
@@ -188,7 +185,7 @@ pub(crate) async fn rewrite_graph_change_records(
     let location = resolve_table_location(namespace, table_id).await?;
     let entry = DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version.version,
         records.len() as u64,
     );
@@ -234,9 +231,8 @@ pub(crate) async fn stage_graph_change_records(
         pinned_version
     };
     let location = resolve_or_declare_table_location(namespace.clone(), table_id).await?;
-    cleanup_unpublished_manifest_versions(&location, Some(pinned_version.version)).await?;
-    let location_path =
-        std::path::PathBuf::from(location.strip_prefix("file://").unwrap_or(&location));
+    cleanup_unpublished_manifest_versions(db_path, &location, Some(pinned_version.version)).await?;
+    let location_path = namespace_location_to_local_path(db_path, &location)?;
     let version = append_lance_batch_at_version(&location_path, &pinned_version, batch).await?;
     let row_count = manifest
         .datasets
@@ -248,7 +244,7 @@ pub(crate) async fn stage_graph_change_records(
     let location = resolve_table_location(namespace, table_id).await?;
     let entry = DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version.version,
         row_count,
     );
@@ -361,7 +357,8 @@ async fn load_existing_internal_entry(
     let version = namespace_latest_version(namespace.clone(), table_id)
         .await?
         .version;
-    let dataset = Dataset::open(&location)
+    let dataset_uri = namespace_location_to_dataset_uri(db_path, &location)?;
+    let dataset = Dataset::open(&dataset_uri)
         .await
         .map_err(|err| NanoError::Lance(format!("open {} error: {}", table_id, err)))?
         .checkout_version(version)
@@ -379,7 +376,7 @@ async fn load_existing_internal_entry(
         as u64;
     Ok(Some(DatasetEntry::internal(
         table_id,
-        manifest_dataset_path(db_path, &location, table_id),
+        manifest_dataset_path(db_path, &location, table_id)?,
         version,
         row_count,
     )))

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1704,6 +1704,112 @@ query q() {
 }
 
 #[tokio::test]
+async fn test_delete_edge_mutation_query_uses_declared_key_for_endpoint_lookup() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(
+        &db_path,
+        r#"
+node Person {
+    slug: String @key
+    name: String
+}
+node Company {
+    slug: String @key
+    name: String
+}
+edge WorksAt: Person -> Company
+"#,
+    )
+    .await
+    .unwrap();
+    db.load(
+        r#"{"type":"Person","data":{"slug":"alice","name":"Alice"}}
+{"type":"Company","data":{"slug":"acme","name":"Acme"}}
+{"edge":"WorksAt","from":"alice","to":"acme"}"#,
+    )
+    .await
+    .unwrap();
+
+    let mut params = ParamMap::new();
+    params.insert(
+        "from".to_string(),
+        nanograph::query::ast::Literal::String("alice".to_string()),
+    );
+    let result = run_db_mutation_test_with_params(
+        r#"
+query remove_work($from: String) {
+    delete WorksAt where from = $from
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result.affected_nodes, 0);
+    assert_eq!(result.affected_edges, 1);
+    let exported = export_rows_for_db(&db).await;
+    let works_at_count = exported
+        .iter()
+        .filter(|row| row.get("edge").and_then(|value| value.as_str()) == Some("WorksAt"))
+        .count();
+    assert_eq!(works_at_count, 0);
+}
+
+#[tokio::test]
+async fn test_delete_edge_mutation_query_missing_endpoint_is_noop() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(
+        &db_path,
+        r#"
+node Person {
+    slug: String @key
+    name: String
+}
+node Company {
+    slug: String @key
+    name: String
+}
+edge WorksAt: Person -> Company
+"#,
+    )
+    .await
+    .unwrap();
+    db.load(
+        r#"{"type":"Person","data":{"slug":"alice","name":"Alice"}}
+{"type":"Company","data":{"slug":"acme","name":"Acme"}}
+{"edge":"WorksAt","from":"alice","to":"acme"}"#,
+    )
+    .await
+    .unwrap();
+
+    let mut params = ParamMap::new();
+    params.insert(
+        "from".to_string(),
+        nanograph::query::ast::Literal::String("nobody".to_string()),
+    );
+    let result = run_db_mutation_test_with_params(
+        r#"
+query remove_work($from: String) {
+    delete WorksAt where from = $from
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result.affected_nodes, 0);
+    assert_eq!(result.affected_edges, 0);
+    let exported = export_rows_for_db(&db).await;
+    let works_at_count = exported
+        .iter()
+        .filter(|row| row.get("edge").and_then(|value| value.as_str()) == Some("WorksAt"))
+        .count();
+    assert_eq!(works_at_count, 1);
+}
+
+#[tokio::test]
 async fn test_delete_mutation_query_cascades_edges() {
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("db");

--- a/docs/user/folder-structure.md
+++ b/docs/user/folder-structure.md
@@ -1,0 +1,66 @@
+---
+title: Database Folder Structure
+slug: folder-structure
+---
+
+# Database Folder Structure
+
+A nanograph database is a single directory with the `.nano` suffix. Everything the engine needs to open, query, and evolve the graph lives inside that folder, so it is easy to move, back up, or delete.
+
+## Layout
+
+```
+<name>.nano/
+├── schema.pg                 # human-authored schema source (.pg DSL)
+├── schema.ir.json            # compiled schema IR used at runtime
+├── _embedding_cache.jsonl    # content-hashed embedding cache (only if @embed is used)
+├── __graph_snapshot/         # Lance table: committed graph snapshot payload
+├── __graph_tx/               # Lance table: committed transaction windows (CDC)
+├── __graph_deletes/          # Lance table: delete tombstones for lineage-native CDC
+├── __graph_changes/          # Lance table: legacy CDC log (older graphs only)
+├── __blob_store/             # Lance table: managed imported media blobs
+├── nodes/<type_id_hex>/      # one Lance dataset per node type
+└── edges/<type_id_hex>/      # one Lance dataset per edge type
+```
+
+Type ID directories under `nodes/` and `edges/` are named by the FNV-1a hash of `"node:TypeName"` or `"edge:TypeName"`, rendered as lowercase u32 hex.
+
+## File and directory reference
+
+### Schema
+
+- `schema.pg` is the source of truth that you edit. It is plain text in the nanograph schema DSL.
+- `schema.ir.json` is the compiled, validated schema IR. The engine rewrites it whenever the schema changes via `nanograph migrate`. Do not edit it by hand.
+
+### Graph data
+
+- `nodes/<type_id_hex>/` holds one Lance dataset per node type declared in the schema. Rows are typed property records.
+- `edges/<type_id_hex>/` holds one Lance dataset per edge type. CSR and CSC adjacency indices are built in memory from these datasets at open time.
+
+### Snapshot and CDC
+
+- `__graph_snapshot/` stores the committed graph snapshot payload that backs the `GraphManifest`.
+- `__graph_tx/` stores committed transaction windows. New graphs use the `NamespaceLineage` generation, which reconstructs CDC from Lance lineage plus this table.
+- `__graph_deletes/` records delete tombstones so lineage-native CDC can report removals.
+- `__graph_changes/` only exists on legacy graphs created before lineage-native CDC. `nanograph storage migrate --target lineage-native` retires it.
+
+### Media and embeddings
+
+- `__blob_store/` is used when media is imported through the managed blob workflow. Databases that only reference external URIs will not have this table.
+- `_embedding_cache.jsonl` caches embeddings keyed by content hash so repeated loads do not re-call the embedding API. It only appears if at least one property uses `@embed`.
+
+## What is not in the folder
+
+Project configuration lives outside `.nano/`:
+
+- `nanograph.toml` sits next to the database and holds shared defaults, query roots, and aliases.
+- `.env.nano` sits next to the database and holds local secrets such as `OPENAI_API_KEY`. It is gitignored by the `nanograph init` scaffold.
+
+See [`config.md`](config.md) for the full config reference.
+
+## Operational notes
+
+- The whole `.nano/` directory is safe to copy, tar, or sync while the database is closed. Do not copy a live database mid-write.
+- `nanograph compact` and `nanograph cleanup` reclaim space inside the Lance datasets. `nanograph doctor` checks the folder for structural issues.
+- Deleting the `.nano/` folder removes the database. Re-running `nanograph init` and `nanograph load` rebuilds it from source data.
+- Version control: `schema.pg` is worth committing. The Lance datasets under `nodes/`, `edges/`, and the `__graph_*` tables are binary and regenerable, so most projects gitignore the `.nano/` folder and keep only schemas and source JSONL in git.

--- a/nanograph.toml
+++ b/nanograph.toml
@@ -1,0 +1,30 @@
+# Shared nanograph project defaults.
+# Keep secrets in .env.nano, not in this file.
+
+[db]
+default_path = "/tmp/no-space.nano"
+
+[schema]
+default_path = "crates/nanograph/tests/fixtures/test.pg"
+
+[query]
+roots = ["queries"]
+
+[embedding]
+provider = "openai"
+model = "text-embedding-3-small"
+batch_size = 64
+chunk_size = 0
+chunk_overlap_chars = 128
+
+[cli]
+table_max_column_width = 80
+
+table_cell_layout = "truncate"
+
+# Example:
+# [query_aliases.search]
+# query = "queries/search.gq"
+# name = "semantic_search"
+# args = ["q"]
+# format = "table"


### PR DESCRIPTION
## Summary

- **Swift SDK**: adds Tier 1 mutation helpers — `upsertNode`, `upsertEdge`, `deleteNode`, `deleteEdgesFrom`, `deleteEdgesTo`, `updateNode`, `updateNodes`, plus a `MutationResult` decoder. Each synthesizes a named `.gq` query and decodes the `{affectedNodes, affectedEdges}` payload. Schema metadata (per-type `@key`, endpoint key types) is cached lazily and invalidated on `close()`.
- **Engine fix**: `resolve_sparse_node_id_by_name` no longer hardcodes a `name` column as the endpoint key. It now reads the declared `@key` from the catalog and supports all scalar key types via the new `edge_endpoint_lookup_value` helper. Returns `Option<u64>` so missing endpoints become silent 0-affected deletes — matching the existing zero-match semantics.
- **Regression tests** across all three layers (core engine integration, CLI suite, Swift SDK).

## Why the engine change
The Swift SDK's `deleteEdgesFrom/To` helpers need to resolve endpoints by the user-declared `@key`. Previously `delete EdgeType where from = $x` only worked if the endpoint node type happened to have `name: String @key` — any schema using `slug`, `uuid`, or integer keys would error with _"edge endpoint lookup requires node type \`X\` to have \`name\` property"_. The fix benefits every SDK (TS too) and the CLI — it wasn't a Swift-only problem.

## Test plan
- [x] `swift test` — 44/44 pass
- [x] `cargo test -p nanograph` — 408/408 pass
- [x] `cargo test -p nanograph-cli` — all suites pass
- [x] New `Tier1MutationTests` covers: happy-path round-trips, silent-on-miss deletes/updates, `@key` write protection, empty-set no-op, unknown-type errors, type-without-`@key` errors, edge idempotency for same `(from, to)`
- [x] New `run_delete_edge_missing_endpoint_returns_zero_affected_without_error` in CLI suite pins the engine semantic

## Known scope boundaries (deliberate)
- `upsertNode`/`upsertEdge` are **full-row replace** via `loadRows(mode: .merge)`, not partial-merge. Partial edits go through `updateNode`. The docstrings state this.
- Edge property values written via `upsertEdge` are not yet projectable back through `.gq` (grammar has no edge-binding form). Writes work; read-back will need a future grammar extension.
- `delete Edge where from = X and to = Y` (compound predicate) remains unsupported by the grammar — hence `deleteEdgesFrom`/`deleteEdgesTo` as separate directional helpers instead of a single `deleteEdge(from:to:)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)