### PR TITLE
fix: reject non-const nearest() query (#9) and unique cycle-close temp var (#8)

### DIFF
--- a/crates/nanograph/src/ir/lower.rs
+++ b/crates/nanograph/src/ir/lower.rs
@@ -22,6 +22,7 @@ pub fn lower_query(
 
     let mut pipeline = Vec::new();
     let mut bound_vars = HashSet::new();
+    let mut temp_counter = 0usize;
 
     lower_clauses(
         catalog,
@@ -30,6 +31,7 @@ pub fn lower_query(
         &mut pipeline,
         &mut bound_vars,
         &param_names,
+        &mut temp_counter,
     )?;
 
     let return_exprs: Vec<IRProjection> = query
@@ -118,6 +120,7 @@ fn lower_clauses(
     pipeline: &mut Vec<IROp>,
     bound_vars: &mut HashSet<String>,
     param_names: &HashSet<String>,
+    temp_counter: &mut usize,
 ) -> Result<()> {
     // Separate clause types for ordering: bindings first, then traversals, then filters
     let mut bindings = Vec::new();
@@ -220,8 +223,12 @@ fn lower_clauses(
         };
 
         if bound_vars.contains(&traversal.src) && bound_vars.contains(&traversal.dst) {
-            // Cycle closing: emit expand to a temp var, then filter temp.id = dst.id
-            let temp_var = format!("__temp_{}", traversal.dst);
+            // Cycle closing / fan-in: emit expand to a fresh temp var, then filter temp.id = dst.id.
+            // The counter keeps the temp var unique across multiple traversals that target the
+            // same already-bound destination (e.g. `$a aToB $b` + `$c cToB $b`), and across
+            // nested AntiJoin pipelines whose schemas merge with the outer.
+            let temp_var = format!("__temp_{}_{}", traversal.dst, *temp_counter);
+            *temp_counter += 1;
             pipeline.push(IROp::Expand {
                 src_var: traversal.src.clone(),
                 dst_var: temp_var.clone(),
@@ -304,6 +311,7 @@ fn lower_clauses(
             &mut inner_pipeline,
             &mut inner_bound,
             param_names,
+            temp_counter,
         )?;
 
         pipeline.push(IROp::AntiJoin {

--- a/crates/nanograph/src/query/typecheck.rs
+++ b/crates/nanograph/src/query/typecheck.rs
@@ -929,6 +929,28 @@ fn resolve_expr_type(
                 ));
             }
 
+            match query.as_ref() {
+                Expr::Literal(_) => {}
+                Expr::Variable(name) if params.contains_key(name) => {}
+                Expr::Variable(name) => {
+                    return Err(NanoError::Type(format!(
+                        "T15: nearest query `${}` must be a declared parameter or literal; \
+                         row-bound variables and property access are not supported \
+                         (fetch the value in a prior query and pass it as a parameter)",
+                        name
+                    )));
+                }
+                _ => {
+                    return Err(NanoError::Type(
+                        "T15: nearest query must be a literal or declared parameter; \
+                         expressions like property access (`$var.prop`) are not supported \
+                         because the query vector must be resolved once, not per row \
+                         (fetch the value in a prior query and pass it as a parameter)"
+                            .to_string(),
+                    ));
+                }
+            }
+
             if let Expr::Literal(lit) = query.as_ref()
                 && let Some(dim) = numeric_vector_literal_dim(lit)
             {
@@ -2003,6 +2025,58 @@ query q($q: String) {
         .unwrap();
         let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
         assert!(ctx.bindings.contains_key("d"));
+    }
+
+    // Regression test for issue #9: `nearest()` query argument must be a literal or
+    // declared parameter. Property access (`$s.text`) parses and resolves to a String,
+    // so it used to slip past lint and only fail at runtime. Reject it statically here.
+    #[test]
+    fn test_nearest_rejects_prop_access_query() {
+        let catalog = setup_vector();
+        let qf = parse_query(
+            r#"
+query q($seed: String) {
+    match {
+        $s: Doc { id_str: $seed }
+        $d: Doc
+    }
+    return { $d.id_str }
+    order { nearest($d.embedding, $s.id_str) }
+    limit 3
+}
+"#,
+        )
+        .unwrap();
+        let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("T15"), "expected T15 error, got: {msg}");
+        assert!(
+            msg.contains("nearest query") && msg.contains("literal or declared parameter"),
+            "expected message about literal-or-param, got: {msg}"
+        );
+    }
+
+    // Regression test for issue #9: a row-bound variable (not a declared param) is also
+    // rejected statically — the runtime can't resolve a single query vector from it.
+    #[test]
+    fn test_nearest_rejects_bound_variable_query() {
+        let catalog = setup_vector();
+        let qf = parse_query(
+            r#"
+query q() {
+    match {
+        $s: Doc
+        $d: Doc
+    }
+    return { $d.id_str }
+    order { nearest($d.embedding, $s) }
+    limit 3
+}
+"#,
+        )
+        .unwrap();
+        let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+        assert!(err.to_string().contains("T15"));
     }
 
     #[test]

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1940,3 +1940,142 @@ async fn test_schema_typecheck_all_valid() {
         );
     }
 }
+
+fn fan_in_schema() -> &'static str {
+    r#"
+node A { slug: String @key }
+node B { slug: String @key }
+node C { slug: String @key }
+
+edge AToB: A -> B
+edge CToB: C -> B
+"#
+}
+
+fn fan_in_data() -> &'static str {
+    r#"{"type":"A","data":{"slug":"a1"}}
+{"type":"A","data":{"slug":"a2"}}
+{"type":"B","data":{"slug":"b1"}}
+{"type":"B","data":{"slug":"b2"}}
+{"type":"C","data":{"slug":"c1"}}
+{"type":"C","data":{"slug":"c2"}}
+{"edge":"AToB","from":"a1","to":"b1"}
+{"edge":"AToB","from":"a2","to":"b2"}
+{"edge":"CToB","from":"c1","to":"b1"}
+{"edge":"CToB","from":"c2","to":"b2"}
+"#
+}
+
+// Regression test for issue #8: two edges landing on the same destination variable
+// previously failed at execution with `number of columns(N) must match number of fields(M)`
+// because the cycle-closing lowering reused a single `__temp_b` name across both
+// traversals, producing duplicate destination columns in the Expand schema.
+#[tokio::test]
+async fn test_fan_in_two_edges_same_destination() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, fan_in_schema()).await.unwrap();
+    db.load(fan_in_data()).await.unwrap();
+
+    let results = run_db_query_test_with_params(
+        r#"
+query fan_in() {
+    match {
+        $a: A
+        $b: B
+        $c: C
+        $a aToB $b
+        $c cToB $b
+    }
+    return { $a.slug as a_slug, $c.slug as c_slug }
+    order { $a.slug asc }
+}
+"#,
+        &db,
+        &ParamMap::new(),
+    )
+    .await;
+
+    let pairs = extract_string_pairs(&results, "a_slug", "c_slug");
+    assert_eq!(
+        pairs,
+        vec![
+            ("a1".to_string(), "c1".to_string()),
+            ("a2".to_string(), "c2".to_string()),
+        ]
+    );
+}
+
+// Regression test for issue #8 (not{} variant): a `not { }` clause containing a
+// traversal whose destination is an outer-bound variable hit the same column-count
+// bug because the inner pipeline's temp var name collided with whatever the outer
+// match emitted for the same destination.
+#[tokio::test]
+async fn test_fan_in_with_negation_on_shared_destination() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, fan_in_schema()).await.unwrap();
+    db.load(fan_in_data()).await.unwrap();
+
+    // Find A nodes that point at a B which is NOT pointed at by any C.
+    // With the fixture, every B has a corresponding C, so this should return zero rows
+    // — the test is about the query *executing* without an Arrow schema error.
+    let results = run_db_query_test_with_params(
+        r#"
+query fan_in_neg() {
+    match {
+        $a: A
+        $b: B
+        $a aToB $b
+        not {
+            $c: C
+            $c cToB $b
+        }
+    }
+    return { $a.slug as a_slug }
+}
+"#,
+        &db,
+        &ParamMap::new(),
+    )
+    .await;
+
+    let names = extract_string_column(&results, "a_slug");
+    assert!(
+        names.is_empty(),
+        "expected zero rows (every B has a matching C), got {names:?}"
+    );
+
+    // Insert an orphan B with no incoming CToB edge and verify the query now finds it.
+    db.load(
+        r#"{"type":"A","data":{"slug":"a3"}}
+{"type":"B","data":{"slug":"b3"}}
+{"edge":"AToB","from":"a3","to":"b3"}
+"#,
+    )
+    .await
+    .unwrap();
+
+    let results = run_db_query_test_with_params(
+        r#"
+query fan_in_neg() {
+    match {
+        $a: A
+        $b: B
+        $a aToB $b
+        not {
+            $c: C
+            $c cToB $b
+        }
+    }
+    return { $a.slug as a_slug }
+}
+"#,
+        &db,
+        &ParamMap::new(),
+    )
+    .await;
+
+    let names = extract_string_column(&results, "a_slug");
+    assert_eq!(names, vec!["a3"]);
+}


### PR DESCRIPTION
## Summary

- **Closes #9**: `nearest($vec, $node.prop)` and `nearest($vec, $bound_var)` are now rejected statically by typecheck (T15) instead of failing at execution. The acceptable shapes for the query argument are a literal or a declared parameter. Per-row evaluation isn't viable because the query vector must be resolved once before scoring — the issue's recommended workaround (fetch the seed in a prior query, pass as `$param`) is what the new error message points users to.
- **Closes #8**: Cycle-closing lowering emitted the same temp var name (`__temp_{dst}`) for every traversal targeting an already-bound destination, so two such traversals in the same pipeline (or a `match` traversal plus a `not { }` traversal sharing a destination) collided and ExpandExec emitted duplicate destination columns — Arrow rejected with `number of columns(N) must match number of fields(M)`. Threaded a counter through `lower_clauses` so each cycle-close gets a unique `__temp_{dst}_{n}`.

## Test plan

- [x] `cargo test -p nanograph --lib nearest_rejects` — 2 new typecheck tests pass
- [x] `cargo test -p nanograph --test engine_integration test_fan_in` — 2 new integration tests pass (one for the plain fan-in, one for the `not { }` variant including the orphan-detection follow-up case)
- [x] `cargo test -p nanograph` — 355 unit + 40 integration + 25 migration tests, all passing
- [x] `cargo clippy -p nanograph --tests` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)