### PR TITLE
release: 1.2.2 — migration validation + query-engine fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,7 +4051,7 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nanograph"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "nanograph-cli"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "ariadne",
  "arrow-array",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "nanograph-ffi"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "arrow-ipc",
  "nanograph",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "nanograph-ts"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "nanograph",
  "napi",

--- a/crates/nanograph-cli/Cargo.toml
+++ b/crates/nanograph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanograph-cli"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 description = "CLI for NanoGraph — the embedded property graph database. No server, schema-as-code."
 repository = "https://github.com/nanograph/nanograph"
@@ -12,7 +12,7 @@ name = "nanograph"
 path = "src/main.rs"
 
 [dependencies]
-nanograph = { path = "../nanograph", version = "1.2.1" }
+nanograph = { path = "../nanograph", version = "1.2.2" }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-cast = { workspace = true }

--- a/crates/nanograph-cli/src/main.rs
+++ b/crates/nanograph-cli/src/main.rs
@@ -1584,8 +1584,8 @@ fn render_visible_change_rows(format: &str, rows: &[VisibleChangeRow]) -> Result
     match format {
         "jsonl" => {
             for row in rows {
-                let line =
-                    serde_json::to_string(row).wrap_err("failed to serialize visible change row")?;
+                let line = serde_json::to_string(row)
+                    .wrap_err("failed to serialize visible change row")?;
                 println!("{}", line);
             }
         }
@@ -1908,7 +1908,11 @@ fn record_property_query(
 fn load_lint_schema(
     db_path: Option<&Path>,
     schema_path: Option<&Path>,
-) -> Result<(PathBuf, nanograph::schema::ast::SchemaFile, Option<SchemaDriftSummary>)> {
+) -> Result<(
+    PathBuf,
+    nanograph::schema::ast::SchemaFile,
+    Option<SchemaDriftSummary>,
+)> {
     let (schema_path, schema_source, drift) = match (db_path, schema_path) {
         (Some(db_path), Some(schema_path)) => (
             schema_path.to_path_buf(),
@@ -1954,7 +1958,11 @@ fn collect_type_mutation_coverage(
                 let entry = coverage.entry(update.type_name.clone()).or_default();
                 push_unique(&mut entry.update_queries, query_name);
                 for assignment in &update.assignments {
-                    record_property_query(&mut entry.update_props, &assignment.property, query_name);
+                    record_property_query(
+                        &mut entry.update_props,
+                        &assignment.property,
+                        query_name,
+                    );
                 }
             }
             Mutation::Insert(_) | Mutation::Delete(_) => {}

--- a/crates/nanograph-cli/src/tests.rs
+++ b/crates/nanograph-cli/src/tests.rs
@@ -29,11 +29,7 @@ fn version_dataset_entries(payload: &serde_json::Value) -> Vec<&serde_json::Valu
         .collect()
 }
 
-fn version_data_dataset_path(
-    payload: &serde_json::Value,
-    kind: &str,
-    type_name: &str,
-) -> String {
+fn version_data_dataset_path(payload: &serde_json::Value, kind: &str, type_name: &str) -> String {
     version_dataset_entries(payload)
         .into_iter()
         .find(|entry| entry["kind"] == kind && entry["type_name"] == type_name)
@@ -1537,9 +1533,13 @@ async fn changes_no_embeddings_still_requires_visible_cdc_history() {
         r#"{"type":"Person","data":{"slug":"alice","summary":"Alpha","embedding":[1.0,0.0,0.0]}}"#,
     );
 
-    Database::init_with_generation(&db_path, &std::fs::read_to_string(&schema_path).unwrap(), StorageGeneration::V4Namespace)
-        .await
-        .unwrap();
+    Database::init_with_generation(
+        &db_path,
+        &std::fs::read_to_string(&schema_path).unwrap(),
+        StorageGeneration::V4Namespace,
+    )
+    .await
+    .unwrap();
     cmd_load(&db_path, &data_path, LoadModeArg::Overwrite, false, false)
         .await
         .unwrap();

--- a/crates/nanograph-cli/tests/namespace_lineage.rs
+++ b/crates/nanograph-cli/tests/namespace_lineage.rs
@@ -75,15 +75,20 @@ fn namespace_lineage_changes_have_full_shape_and_deterministic_ordering() {
     assert!(rows.iter().all(|row| row.get("db_version").is_none()));
     assert!(rows.iter().all(|row| row.get("seq_in_tx").is_none()));
     assert!(
-        rows.iter().all(|row| row["graph_version"].as_u64() == Some(graph_version))
+        rows.iter()
+            .all(|row| row["graph_version"].as_u64() == Some(graph_version))
     );
     assert!(
-        rows.iter().all(|row| row["previous_graph_version"].as_u64() == Some(before_version))
+        rows.iter()
+            .all(|row| row["previous_graph_version"].as_u64() == Some(before_version))
     );
     assert!(rows.iter().all(|row| row["tx_id"].is_string()));
     assert!(rows.iter().all(|row| row["table_id"].is_string()));
     assert!(rows.iter().all(|row| row["rowid"].is_u64()));
-    assert!(rows.iter().all(|row| row["entity_id"].as_u64().unwrap_or(0) > 0));
+    assert!(
+        rows.iter()
+            .all(|row| row["entity_id"].as_u64().unwrap_or(0) > 0)
+    );
     assert!(rows.iter().all(|row| row["logical_key"].is_string()));
     assert!(rows.iter().all(|row| row["row"].is_object()));
 

--- a/crates/nanograph-cli/tests/revops_admin_and_cdc.rs
+++ b/crates/nanograph-cli/tests/revops_admin_and_cdc.rs
@@ -242,13 +242,17 @@ query delete_task() {
             .any(|row| row["change_kind"].as_str() == Some("delete"))
     );
     assert!(
-        changes_range.iter().all(|row| row.get("db_version").is_none())
-            && changes_range.iter().all(|row| row.get("seq_in_tx").is_none())
+        changes_range
+            .iter()
+            .all(|row| row.get("db_version").is_none())
+            && changes_range
+                .iter()
+                .all(|row| row.get("seq_in_tx").is_none())
     );
     assert!(
-        changes_range.iter().any(|row| {
-            row["type_name"] == "Signal" && row["row"]["urgency"] == "critical"
-        })
+        changes_range
+            .iter()
+            .any(|row| { row["type_name"] == "Signal" && row["row"]["urgency"] == "critical" })
     );
 
     let changes_since = workspace.jsonl_rows(&[

--- a/crates/nanograph-ffi/Cargo.toml
+++ b/crates/nanograph-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanograph-ffi"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 description = "NanoGraph C ABI for Swift and other native clients"
 repository = "https://github.com/nanograph/nanograph"
@@ -10,7 +10,7 @@ license = "MIT"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-nanograph = { path = "../nanograph", version = "1.2.1" }
+nanograph = { path = "../nanograph", version = "1.2.2" }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 arrow-ipc = { workspace = true }

--- a/crates/nanograph-ts/Cargo.toml
+++ b/crates/nanograph-ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanograph-ts"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 description = "NanoGraph TypeScript/Node.js SDK via napi-rs"
 repository = "https://github.com/nanograph/nanograph"
@@ -10,7 +10,7 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-nanograph = { path = "../nanograph", version = "1.2.1" }
+nanograph = { path = "../nanograph", version = "1.2.2" }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 tokio = { workspace = true }

--- a/crates/nanograph-ts/package.json
+++ b/crates/nanograph-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanograph-db",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "NanoGraph — embedded typed property graph DB for TypeScript/Node.js",
   "main": "index.js",
   "types": "types.d.ts",

--- a/crates/nanograph-ts/src/convert.rs
+++ b/crates/nanograph-ts/src/convert.rs
@@ -139,7 +139,11 @@ pub fn parse_changes_options(opts: Option<&serde_json::Value>) -> napi::Result<C
                 to_graph_version_inclusive: None,
             });
         }
-        Some(_) => return Err(napi::Error::from_reason("changes options must be an object")),
+        Some(_) => {
+            return Err(napi::Error::from_reason(
+                "changes options must be an object",
+            ));
+        }
     };
 
     for key in obj.keys() {

--- a/crates/nanograph-ts/src/lib.rs
+++ b/crates/nanograph-ts/src/lib.rs
@@ -17,8 +17,8 @@ use nanograph::query::typecheck::{CheckedQuery, typecheck_query_decl};
 use nanograph::store::database::Database;
 
 use convert::{
-    js_object_to_param_map, parse_changes_options, parse_cleanup_options,
-    parse_compact_options, parse_embed_options, parse_load_mode,
+    js_object_to_param_map, parse_changes_options, parse_cleanup_options, parse_compact_options,
+    parse_embed_options, parse_load_mode,
 };
 
 fn to_napi_err(e: NanoError) -> napi::Error {

--- a/crates/nanograph/Cargo.toml
+++ b/crates/nanograph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nanograph"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 description = "Embedded typed property graph database. Schema-as-code, compile-time validated, Arrow-native."
 repository = "https://github.com/nanograph/nanograph"

--- a/crates/nanograph/src/store/blob_store.rs
+++ b/crates/nanograph/src/store/blob_store.rs
@@ -18,10 +18,9 @@ use crate::store::lance_io::{
 use crate::store::manifest::DatasetEntry;
 use crate::store::namespace::{
     BLOB_STORE_TABLE_ID, batch_publish_namespace_versions, local_path_to_file_uri,
-    namespace_published_version_for_table, namespace_location_to_dataset_uri,
-    namespace_location_to_local_path,
-    namespace_location_to_manifest_dataset_path, open_directory_namespace,
-    resolve_table_location, write_namespace_batch,
+    namespace_location_to_dataset_uri, namespace_location_to_local_path,
+    namespace_location_to_manifest_dataset_path, namespace_published_version_for_table,
+    open_directory_namespace, resolve_table_location, write_namespace_batch,
 };
 use crate::store::snapshot::read_committed_graph_snapshot;
 use crate::store::storage_generation::{StorageGeneration, detect_storage_generation};
@@ -272,17 +271,19 @@ pub(crate) async fn current_blob_store_entry(db_path: &Path) -> Result<Option<Da
             let location_path = namespace_location_to_local_path(db_path, &location)?;
             let version = latest_lance_dataset_version(&location_path).await?;
             let dataset_uri = namespace_location_to_dataset_uri(db_path, &location)?;
-            let dataset = Dataset::open(&dataset_uri).await.map_err(|err| {
-                NanoError::Lance(format!("open namespace blob store error: {}", err))
-            })?
-            .checkout_version(version)
-            .await
-            .map_err(|err| {
-                NanoError::Lance(format!(
-                    "checkout namespace blob store version {} error: {}",
-                    version, err
-                ))
-            })?;
+            let dataset = Dataset::open(&dataset_uri)
+                .await
+                .map_err(|err| {
+                    NanoError::Lance(format!("open namespace blob store error: {}", err))
+                })?
+                .checkout_version(version)
+                .await
+                .map_err(|err| {
+                    NanoError::Lance(format!(
+                        "checkout namespace blob store version {} error: {}",
+                        version, err
+                    ))
+                })?;
             let row_count =
                 dataset.count_rows(None).await.map_err(|err| {
                     NanoError::Lance(format!("count blob store rows error: {}", err))
@@ -588,7 +589,11 @@ node Note {
         let fixture_dir = temp.path().join("fixtures");
         std::fs::create_dir_all(&fixture_dir).unwrap();
         let image_path = fixture_dir.join("space.png");
-        std::fs::write(&image_path, b"\x89PNG\r\n\x1a\nblob-store-visible-after-load").unwrap();
+        std::fs::write(
+            &image_path,
+            b"\x89PNG\r\n\x1a\nblob-store-visible-after-load",
+        )
+        .unwrap();
         let data_path = fixture_dir.join("data.jsonl");
         std::fs::write(
             &data_path,
@@ -736,8 +741,11 @@ query asset_uri($slug: String) {
             RunResult::Query(rows) => rows.to_rust_json(),
             other => panic!("expected query rows, got {:?}", other),
         };
-        let blob_id_before = parse_managed_blob_id(rows_before[0]["uri"].as_str().unwrap()).unwrap();
-        let bytes_before = read_managed_blob_bytes(&db_path, blob_id_before).await.unwrap();
+        let blob_id_before =
+            parse_managed_blob_id(rows_before[0]["uri"].as_str().unwrap()).unwrap();
+        let bytes_before = read_managed_blob_bytes(&db_path, blob_id_before)
+            .await
+            .unwrap();
         assert_eq!(bytes_before, b"\x89PNG\r\n\x1a\nblob-store-after-migration");
 
         std::fs::write(db_path.join("schema.pg"), embed_schema).unwrap();
@@ -758,11 +766,9 @@ query asset_uri($slug: String) {
             committed_blob_after
         );
         assert_eq!(
-            committed_blob_after.dataset_version,
-            committed_blob_before.dataset_version,
+            committed_blob_after.dataset_version, committed_blob_before.dataset_version,
             "blob store version changed across schema migration: before={} after={}",
-            committed_blob_before.dataset_version,
-            committed_blob_after.dataset_version
+            committed_blob_before.dataset_version, committed_blob_after.dataset_version
         );
 
         let reopened = Database::open(&db_path).await.unwrap();

--- a/crates/nanograph/src/store/database/maintenance.rs
+++ b/crates/nanograph/src/store/database/maintenance.rs
@@ -21,7 +21,9 @@ use super::{
 use crate::catalog::schema_ir::SchemaIR;
 use crate::error::{NanoError, Result};
 use crate::store::graph_mirror::{inspect_graph_mirror, rebuild_graph_mirror_from_wal};
-use crate::store::graph_types::{GraphChangeRecord, GraphCommitRecord, GraphDeleteRecord, GraphTouchedTableWindow};
+use crate::store::graph_types::{
+    GraphChangeRecord, GraphCommitRecord, GraphDeleteRecord, GraphTouchedTableWindow,
+};
 use crate::store::lance_io::{
     LANCE_INTERNAL_ID_FIELD, open_dataset_for_locator, write_lance_batch,
 };
@@ -39,11 +41,11 @@ use crate::store::namespace_lineage_graph_log::{
 use crate::store::snapshot::{graph_snapshot_table_present, read_committed_graph_snapshot};
 use crate::store::storage_generation::{StorageGeneration, detect_storage_generation};
 use crate::store::txlog::{
-    CdcLogEntry, collect_visible_lineage_shadow_cdc_entries, commit_manifest_and_logs,
-    commit_graph_records_and_manifest_namespace_lineage, prune_logs_for_replay_window,
-    read_cdc_log_entries, read_tx_catalog_entries, read_visible_change_rows,
-    read_visible_graph_delete_records_namespace_lineage,
-    read_visible_cdc_entries, read_visible_graph_change_records, read_visible_graph_commit_records,
+    CdcLogEntry, collect_visible_lineage_shadow_cdc_entries,
+    commit_graph_records_and_manifest_namespace_lineage, commit_manifest_and_logs,
+    prune_logs_for_replay_window, read_cdc_log_entries, read_tx_catalog_entries,
+    read_visible_cdc_entries, read_visible_change_rows, read_visible_graph_change_records,
+    read_visible_graph_commit_records, read_visible_graph_delete_records_namespace_lineage,
     reconcile_logs_to_manifest,
 };
 use crate::store::v4_graph_log::{rewrite_graph_change_records, rewrite_graph_commit_records};
@@ -131,7 +133,10 @@ pub async fn compact_database(db_path: &Path, options: CompactOptions) -> Result
                         &next_manifest,
                     ),
                     tx_props: BTreeMap::from([
-                        ("graph_version".to_string(), next_manifest.db_version.to_string()),
+                        (
+                            "graph_version".to_string(),
+                            next_manifest.db_version.to_string(),
+                        ),
                         ("tx_id".to_string(), next_manifest.last_tx_id.clone()),
                         ("op_summary".to_string(), "maintenance:compact".to_string()),
                     ]),
@@ -170,7 +175,10 @@ pub async fn cleanup_database(db_path: &Path, options: CleanupOptions) -> Result
             "retain_tx_versions must be >= 1".to_string(),
         ));
     }
-    if matches!(storage_generation, Some(StorageGeneration::NamespaceLineage)) {
+    if matches!(
+        storage_generation,
+        Some(StorageGeneration::NamespaceLineage)
+    ) {
         return cleanup_database_namespace_lineage(db_path, options).await;
     }
     if options.retain_dataset_versions == 0 {
@@ -192,26 +200,29 @@ pub async fn cleanup_database(db_path: &Path, options: CleanupOptions) -> Result
     let v4_retained_window = v4_all_commits
         .as_ref()
         .map(|commits| select_retained_v4_graph_window(commits, options.retain_tx_versions));
-    let v4_lineage_required_versions = v4_all_commits
-        .as_ref()
-        .map(|commits| compute_v4_lineage_required_versions(&manifest, commits, options.retain_tx_versions));
+    let v4_lineage_required_versions = v4_all_commits.as_ref().map(|commits| {
+        compute_v4_lineage_required_versions(&manifest, commits, options.retain_tx_versions)
+    });
     let log_prune = prune_logs_for_replay_window(db_path, options.retain_tx_versions)?;
     let mut result = if matches!(storage_generation, Some(StorageGeneration::V4Namespace)) {
         let retained = v4_retained_window.as_ref().expect("v4 retained window");
-        let retained_changes =
-            read_visible_graph_change_records(
-                db_path,
-                retained.lower_bound_exclusive,
-                Some(manifest.db_version),
-            )?;
+        let retained_changes = read_visible_graph_change_records(
+            db_path,
+            retained.lower_bound_exclusive,
+            Some(manifest.db_version),
+        )?;
         CleanupResult {
             tx_rows_removed: read_tx_catalog_entries(db_path)?
                 .len()
                 .saturating_sub(retained.logical_commits.len()),
             tx_rows_kept: retained.logical_commits.len(),
-            cdc_rows_removed: read_visible_graph_change_records(db_path, 0, Some(manifest.db_version))?
-                .len()
-                .saturating_sub(retained_changes.len()),
+            cdc_rows_removed: read_visible_graph_change_records(
+                db_path,
+                0,
+                Some(manifest.db_version),
+            )?
+            .len()
+            .saturating_sub(retained_changes.len()),
             cdc_rows_kept: retained_changes.len(),
             ..Default::default()
         }
@@ -253,23 +264,24 @@ pub async fn cleanup_database(db_path: &Path, options: CleanupOptions) -> Result
                 options.retain_dataset_versions.max(needed_for_manifest)
             })
             .unwrap_or(options.retain_dataset_versions);
-        let effective_retain_n = if matches!(storage_generation, Some(StorageGeneration::V4Namespace))
-            && matches!(entry.kind.as_str(), "node" | "edge")
-        {
-            v4_lineage_required_versions
-                .as_ref()
-                .and_then(|required| required.get(entry.effective_table_id()))
-                .and_then(|oldest_required| {
-                    versions
-                        .iter()
-                        .position(|version| version.version == *oldest_required)
-                        .map(|idx| versions.len().saturating_sub(idx))
-                })
-                .map(|needed_for_lineage| effective_retain_n.max(needed_for_lineage))
-                .unwrap_or(effective_retain_n)
-        } else {
-            effective_retain_n
-        };
+        let effective_retain_n =
+            if matches!(storage_generation, Some(StorageGeneration::V4Namespace))
+                && matches!(entry.kind.as_str(), "node" | "edge")
+            {
+                v4_lineage_required_versions
+                    .as_ref()
+                    .and_then(|required| required.get(entry.effective_table_id()))
+                    .and_then(|oldest_required| {
+                        versions
+                            .iter()
+                            .position(|version| version.version == *oldest_required)
+                            .map(|idx| versions.len().saturating_sub(idx))
+                    })
+                    .map(|needed_for_lineage| effective_retain_n.max(needed_for_lineage))
+                    .unwrap_or(effective_retain_n)
+            } else {
+                effective_retain_n
+            };
         let policy = CleanupPolicyBuilder::default()
             .retain_n_versions(&dataset, effective_retain_n)
             .await
@@ -288,12 +300,11 @@ pub async fn cleanup_database(db_path: &Path, options: CleanupOptions) -> Result
 
     if matches!(storage_generation, Some(StorageGeneration::V4Namespace)) {
         let retained = v4_retained_window.as_ref().expect("v4 retained window");
-        let retained_changes =
-            read_visible_graph_change_records(
-                db_path,
-                retained.lower_bound_exclusive,
-                Some(manifest.db_version),
-            )?;
+        let retained_changes = read_visible_graph_change_records(
+            db_path,
+            retained.lower_bound_exclusive,
+            Some(manifest.db_version),
+        )?;
         let staged_tx = rewrite_graph_commit_records(db_path, &retained.staged_commits).await?;
         let staged_changes = rewrite_graph_change_records(db_path, &retained_changes).await?;
         let mut next_snapshot = manifest.clone();
@@ -303,12 +314,8 @@ pub async fn cleanup_database(db_path: &Path, options: CleanupOptions) -> Result
         next_snapshot
             .datasets
             .retain(|entry| !replaced_ids.contains(entry.effective_table_id()));
-        next_snapshot
-            .datasets
-            .push(staged_tx.entry.clone());
-        next_snapshot
-            .datasets
-            .push(staged_changes.entry.clone());
+        next_snapshot.datasets.push(staged_tx.entry.clone());
+        next_snapshot.datasets.push(staged_changes.entry.clone());
         publish_snapshot_bundle_with_staged_entries(
             db_path,
             &next_snapshot,
@@ -337,10 +344,8 @@ async fn cleanup_database_namespace_lineage(
     cleanup_namespace_orphan_versions(db_path, &manifest).await?;
 
     let all_commits = read_visible_graph_commit_records(db_path)?;
-    let retained = select_retained_namespace_lineage_graph_window(
-        &all_commits,
-        options.retain_tx_versions,
-    );
+    let retained =
+        select_retained_namespace_lineage_graph_window(&all_commits, options.retain_tx_versions);
     let retained_deletes = read_visible_graph_delete_records_namespace_lineage(
         db_path,
         retained.lower_bound_exclusive,
@@ -352,13 +357,16 @@ async fn cleanup_database_namespace_lineage(
         retained.lower_bound_exclusive,
         Some(manifest.db_version),
     )?;
-    let required_versions =
-        compute_namespace_lineage_required_versions(&retained.logical_commits);
+    let required_versions = compute_namespace_lineage_required_versions(&retained.logical_commits);
 
     let mut result = CleanupResult {
-        tx_rows_removed: all_commits.len().saturating_sub(retained.logical_commits.len()),
+        tx_rows_removed: all_commits
+            .len()
+            .saturating_sub(retained.logical_commits.len()),
         tx_rows_kept: retained.logical_commits.len(),
-        cdc_rows_removed: total_change_rows.len().saturating_sub(retained_change_rows.len()),
+        cdc_rows_removed: total_change_rows
+            .len()
+            .saturating_sub(retained_change_rows.len()),
         cdc_rows_kept: retained_change_rows.len(),
         ..Default::default()
     };
@@ -413,11 +421,8 @@ async fn cleanup_database_namespace_lineage(
         result.dataset_bytes_removed += stats.bytes_removed;
     }
 
-    let staged_tx = rewrite_namespace_lineage_graph_commit_records(
-        db_path,
-        &retained.logical_commits,
-    )
-    .await?;
+    let staged_tx =
+        rewrite_namespace_lineage_graph_commit_records(db_path, &retained.logical_commits).await?;
     let staged_deletes = rewrite_graph_delete_records(db_path, &retained_deletes).await?;
     let mut next_snapshot = manifest.clone();
     let replaced_ids = [GRAPH_TX_TABLE_ID, GRAPH_DELETES_TABLE_ID]
@@ -464,7 +469,10 @@ fn select_retained_v4_graph_window(
     let logical_start = commits.len().saturating_sub(retain_count);
     let logical_commits = commits[logical_start..].to_vec();
     let mut staged_commits = logical_commits.clone();
-    if let Some(predecessor) = logical_start.checked_sub(1).and_then(|idx| commits.get(idx)) {
+    if let Some(predecessor) = logical_start
+        .checked_sub(1)
+        .and_then(|idx| commits.get(idx))
+    {
         staged_commits.insert(0, predecessor.clone());
     }
     let lower_bound_exclusive = logical_commits
@@ -562,7 +570,9 @@ fn compute_namespace_lineage_required_versions(
         for window in &commit.touched_tables {
             if window.before_version > 0 {
                 out.entry(window.table_id.as_str().to_string())
-                    .and_modify(|version: &mut u64| *version = (*version).min(window.before_version))
+                    .and_modify(|version: &mut u64| {
+                        *version = (*version).min(window.before_version)
+                    })
                     .or_insert(window.before_version);
             }
             if window.after_version > 0 {
@@ -823,7 +833,10 @@ impl Database {
             }
         }
 
-        if matches!(storage_generation, Some(StorageGeneration::NamespaceLineage)) {
+        if matches!(
+            storage_generation,
+            Some(StorageGeneration::NamespaceLineage)
+        ) {
             let namespace = open_directory_namespace(&self.path).await?;
             for required in [
                 GRAPH_TX_TABLE_ID,
@@ -901,17 +914,15 @@ impl Database {
         }
 
         let cdc_rows = match storage_generation {
-            Some(StorageGeneration::NamespaceLineage) => match read_visible_change_rows(
-                &self.path,
-                0,
-                Some(manifest.db_version),
-            ) {
-                Ok(rows) => rows.len(),
-                Err(err) => {
-                    issues.push(format!("NamespaceLineage CDC read failed: {}", err));
-                    0
+            Some(StorageGeneration::NamespaceLineage) => {
+                match read_visible_change_rows(&self.path, 0, Some(manifest.db_version)) {
+                    Ok(rows) => rows.len(),
+                    Err(err) => {
+                        issues.push(format!("NamespaceLineage CDC read failed: {}", err));
+                        0
+                    }
                 }
-            },
+            }
             _ => match read_cdc_log_entries(&self.path) {
                 Ok(rows) => rows.len(),
                 Err(err) if matches!(storage_generation, Some(StorageGeneration::V4Namespace)) => {
@@ -1005,12 +1016,11 @@ async fn validate_namespace_lineage_state(
         }
     }
 
-    let deletes =
-        read_visible_graph_delete_records_namespace_lineage(
-            metadata.path(),
-            0,
-            Some(manifest.db_version),
-        )?;
+    let deletes = read_visible_graph_delete_records_namespace_lineage(
+        metadata.path(),
+        0,
+        Some(manifest.db_version),
+    )?;
     validate_namespace_lineage_delete_records(&deletes, issues, warnings);
 
     if let Err(err) = read_visible_change_rows(metadata.path(), 0, Some(manifest.db_version)) {

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -1479,8 +1479,7 @@ pub(crate) async fn persist_dataset_mutation_plan_at_path(
             merge_v4_internal_dataset_entries(db_path, &mut dataset_entries).await?;
         }
         Some(StorageGeneration::NamespaceLineage) => {
-            merge_namespace_lineage_internal_dataset_entries(db_path, &mut dataset_entries)
-                .await?;
+            merge_namespace_lineage_internal_dataset_entries(db_path, &mut dataset_entries).await?;
         }
         None => {}
     }
@@ -1525,7 +1524,10 @@ pub(crate) async fn persist_dataset_mutation_plan_at_path(
             ("op_summary".to_string(), plan.op_summary.clone()),
         ]),
     };
-    if matches!(storage_generation, Some(StorageGeneration::NamespaceLineage)) {
+    if matches!(
+        storage_generation,
+        Some(StorageGeneration::NamespaceLineage)
+    ) {
         let graph_deletes = build_namespace_lineage_delete_records_from_delta(
             db_path,
             &previous_manifest,
@@ -1820,7 +1822,7 @@ async fn map_sparse_edge_delete_predicate(
                 .get(edge_type_name)
                 .ok_or_else(|| {
                     NanoError::Execution(format!("unknown edge type `{}`", edge_type_name))
-            })?;
+                })?;
             let endpoint = resolve_mutation_match_value(value, params)?;
             let endpoint_name = literal_to_endpoint_name(&endpoint, "from")?;
             let Some(src_id) =
@@ -1842,7 +1844,7 @@ async fn map_sparse_edge_delete_predicate(
                 .get(edge_type_name)
                 .ok_or_else(|| {
                     NanoError::Execution(format!("unknown edge type `{}`", edge_type_name))
-            })?;
+                })?;
             let endpoint = resolve_mutation_match_value(value, params)?;
             let endpoint_name = literal_to_endpoint_name(&endpoint, "to")?;
             let Some(dst_id) =
@@ -1889,14 +1891,12 @@ pub(crate) async fn resolve_sparse_node_id_by_name(
         .as_any()
         .downcast_ref::<UInt64Array>()
         .ok_or_else(|| NanoError::Execution("node id column is not UInt64".to_string()))?;
-    let key_col = batch
-        .column_by_name(key_prop)
-        .ok_or_else(|| {
-            NanoError::Execution(format!(
-                "edge endpoint lookup requires node type `{}` to materialize @key property `{}`",
-                node_type, key_prop
-            ))
-        })?;
+    let key_col = batch.column_by_name(key_prop).ok_or_else(|| {
+        NanoError::Execution(format!(
+            "edge endpoint lookup requires node type `{}` to materialize @key property `{}`",
+            node_type, key_prop
+        ))
+    })?;
 
     for row in 0..batch.num_rows() {
         if edge_endpoint_lookup_value(key_col, row).as_deref() == Some(node_name) {
@@ -2359,7 +2359,8 @@ async fn build_namespace_lineage_delete_records_for_batch(
         .find(|entry| entry.kind == entity_kind && entry.type_name == type_name)
         .map(|entry| entry.effective_table_id().to_string())
         .unwrap_or_else(|| locator.table_id.clone());
-    let previous_graph_version = (previous_manifest.db_version > 0).then_some(previous_manifest.db_version);
+    let previous_graph_version =
+        (previous_manifest.db_version > 0).then_some(previous_manifest.db_version);
 
     let mut out = Vec::with_capacity(batch.num_rows());
     for row in 0..batch.num_rows() {

--- a/crates/nanograph/src/store/database/tests.rs
+++ b/crates/nanograph/src/store/database/tests.rs
@@ -16,8 +16,8 @@ use crate::store::metadata::DatabaseMetadata;
 use crate::store::migration::{MigrationStatus, execute_schema_migration};
 use crate::store::namespace::{
     GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID,
-    cleanup_namespace_orphan_versions, namespace_location_to_local_path,
-    open_directory_namespace, resolve_table_location, write_namespace_batch,
+    cleanup_namespace_orphan_versions, namespace_location_to_local_path, open_directory_namespace,
+    resolve_table_location, write_namespace_batch,
 };
 use crate::store::namespace_commit::{build_graph_update_bundle, publish_graph_commit_bundle};
 use crate::store::snapshot::{
@@ -27,8 +27,7 @@ use crate::store::storage_generation::{StorageGeneration, storage_metadata_path}
 use crate::store::txlog::{
     VisibleCdcSource, append_tx_catalog_entry, collect_visible_lineage_shadow_cdc_entries,
     read_tx_catalog_entries, read_visible_cdc_entries, read_visible_cdc_entries_with_source,
-    read_visible_change_rows, read_visible_graph_change_records,
-    read_visible_graph_commit_records,
+    read_visible_change_rows, read_visible_graph_change_records, read_visible_graph_commit_records,
 };
 use arrow_array::{Array, StringArray, UInt32Array, UInt64Array};
 use arrow_schema::{Field, Schema};
@@ -1117,8 +1116,7 @@ async fn test_v4_staged_internal_bundle_is_invisible_until_publish() {
     let committed_after_stage = read_committed_graph_snapshot(path).unwrap();
     let tx_after_stage = read_tx_catalog_entries(path).unwrap();
     let changes_after_stage =
-        read_visible_graph_change_records(path, 0, Some(committed_after_stage.db_version))
-            .unwrap();
+        read_visible_graph_change_records(path, 0, Some(committed_after_stage.db_version)).unwrap();
     let exported_before_publish = build_export_rows_at_path(path, false, true).await.unwrap();
 
     assert_eq!(
@@ -1668,9 +1666,7 @@ async fn test_v5_changes_returns_lineage_native_rows_for_merge() {
     assert_eq!(update.entity_id, alice_id);
     assert!(
         rows.iter().any(|row| {
-            row.change_kind == "insert"
-                && row.entity_kind == "edge"
-                && row.type_name == "Knows"
+            row.change_kind == "insert" && row.entity_kind == "edge" && row.type_name == "Knows"
         }),
         "expected lineage-native rows to include the new Knows edge: {rows:?}"
     );
@@ -3110,11 +3106,9 @@ async fn test_delete_nodes_cascades_edges() {
     assert_eq!(tx_rows[1].op_summary, "mutation:delete_nodes");
 
     let change_rows = read_visible_change_rows(path, 1, Some(2)).unwrap();
-    assert!(
-        change_rows
-            .iter()
-            .any(|row| row.change_kind == "delete" && row.entity_kind == "node" && row.type_name == "Person")
-    );
+    assert!(change_rows.iter().any(|row| row.change_kind == "delete"
+        && row.entity_kind == "node"
+        && row.type_name == "Person"));
     assert!(
         change_rows
             .iter()

--- a/crates/nanograph/src/store/lance_io.rs
+++ b/crates/nanograph/src/store/lance_io.rs
@@ -390,14 +390,8 @@ pub(crate) async fn append_lance_batch_at_version_for_kind(
     batch: RecordBatch,
     kind: LanceDatasetKind,
 ) -> Result<GraphTableVersion> {
-    append_lance_batch_at_version_for_kind_with_properties(
-        path,
-        pinned_version,
-        batch,
-        kind,
-        None,
-    )
-    .await
+    append_lance_batch_at_version_for_kind_with_properties(path, pinned_version, batch, kind, None)
+        .await
 }
 
 pub(crate) async fn append_lance_batch_at_version_for_kind_with_properties(
@@ -605,24 +599,25 @@ pub(crate) async fn cleanup_unpublished_manifest_versions(
         Err(_err) if published_version.is_none() => return Ok(0),
         Err(err) => return Err(NanoError::Lance(format!("cleanup open error: {}", err))),
     };
-    let versions_dir = namespace_location_to_local_path(db_dir, dataset_location)?.join("_versions");
+    let versions_dir =
+        namespace_location_to_local_path(db_dir, dataset_location)?.join("_versions");
     let unpublished = std::fs::read_dir(versions_dir)?
-    .filter_map(|entry| entry.ok())
-    .filter_map(|entry| {
-        let path = entry.path();
-        let file_name = path.file_name()?.to_str()?;
-        let version = lance_table::io::commit::ManifestNamingScheme::detect_scheme(file_name)
-            .and_then(|scheme| scheme.parse_version(file_name))
-            .or_else(|| {
-                lance_table::io::commit::ManifestNamingScheme::parse_detached_version(file_name)
-            })?;
-        let should_remove = match published_version {
-            Some(published_version) => version > published_version,
-            None => true,
-        };
-        should_remove.then_some((path, version))
-    })
-    .collect::<Vec<_>>();
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let path = entry.path();
+            let file_name = path.file_name()?.to_str()?;
+            let version = lance_table::io::commit::ManifestNamingScheme::detect_scheme(file_name)
+                .and_then(|scheme| scheme.parse_version(file_name))
+                .or_else(|| {
+                    lance_table::io::commit::ManifestNamingScheme::parse_detached_version(file_name)
+                })?;
+            let should_remove = match published_version {
+                Some(published_version) => version > published_version,
+                None => true,
+            };
+            should_remove.then_some((path, version))
+        })
+        .collect::<Vec<_>>();
     if unpublished.is_empty() {
         return Ok(0);
     }
@@ -639,14 +634,12 @@ pub(crate) async fn open_dataset_for_locator(locator: &DatasetLocator) -> Result
         let namespace = open_directory_namespace(&locator.db_path).await?;
         let location = resolve_table_location(namespace, &locator.table_id).await?;
         let dataset_uri = namespace_location_to_dataset_uri(&locator.db_path, &location)?;
-        let dataset = Dataset::open(&dataset_uri)
-            .await
-            .map_err(|e| {
-                NanoError::Lance(format!(
-                    "namespace dataset {} open error: {}",
-                    locator.table_id, e
-                ))
-            })?;
+        let dataset = Dataset::open(&dataset_uri).await.map_err(|e| {
+            NanoError::Lance(format!(
+                "namespace dataset {} open error: {}",
+                locator.table_id, e
+            ))
+        })?;
         return dataset
             .checkout_version(locator.dataset_version)
             .await
@@ -922,8 +915,12 @@ impl TableStore for V4NamespaceTableStore {
         let table_id = self.table_id_for_path(path)?;
         let namespace = open_directory_namespace(&self.db_path).await?;
         let location = resolve_or_declare_table_location(namespace, &table_id).await?;
-        cleanup_unpublished_manifest_versions(&self.db_path, &location, Some(pinned_version.version))
-            .await?;
+        cleanup_unpublished_manifest_versions(
+            &self.db_path,
+            &location,
+            Some(pinned_version.version),
+        )
+        .await?;
         let location_path = namespace_location_to_local_path(&self.db_path, &location)?;
         run_lance_merge_insert_with_key_versioned_for_kind(
             &location_path,
@@ -944,8 +941,12 @@ impl TableStore for V4NamespaceTableStore {
         let table_id = self.table_id_for_path(path)?;
         let namespace = open_directory_namespace(&self.db_path).await?;
         let location = resolve_or_declare_table_location(namespace, &table_id).await?;
-        cleanup_unpublished_manifest_versions(&self.db_path, &location, Some(pinned_version.version))
-            .await?;
+        cleanup_unpublished_manifest_versions(
+            &self.db_path,
+            &location,
+            Some(pinned_version.version),
+        )
+        .await?;
         let location_path = namespace_location_to_local_path(&self.db_path, &location)?;
         run_lance_delete_by_ids_versioned(&location_path, pinned_version, ids).await
     }

--- a/crates/nanograph/src/store/loader.rs
+++ b/crates/nanograph/src/store/loader.rs
@@ -19,6 +19,10 @@ mod embeddings;
 mod jsonl;
 mod merge;
 
+pub(crate) use constraints::{
+    key_value_string, load_node_constraint_annotations, unique_value_string,
+    validate_storage_against_schema,
+};
 pub(crate) use embeddings::{
     EmbedInput, EmbedSourceKind, EmbedSpec, EmbedValueRequest, collect_embed_specs,
     resolve_embedding_requests,

--- a/crates/nanograph/src/store/loader/constraints.rs
+++ b/crates/nanograph/src/store/loader/constraints.rs
@@ -1,15 +1,14 @@
-use std::collections::HashMap;
-#[cfg(test)]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use arrow_array::{
     Array, ArrayRef, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array,
-    Int32Array, Int64Array, StringArray, UInt32Array, UInt64Array,
+    Int32Array, Int64Array, ListArray, RecordBatch, StringArray, UInt32Array, UInt64Array,
 };
 use arrow_schema::{DataType, Field, Schema};
 
-use crate::catalog::schema_ir::SchemaIR;
+use crate::catalog::schema_ir::{EdgeTypeDef, NodeTypeDef, PropDef, SchemaIR};
 use crate::error::{NanoError, Result};
+use crate::types::{PropType, ScalarType};
 
 use super::super::graph::DatasetAccumulator;
 
@@ -93,6 +92,305 @@ pub(crate) fn enforce_node_unique_constraints(
             }
         }
     }
+    Ok(())
+}
+
+pub(crate) fn validate_storage_against_schema(
+    schema_ir: &SchemaIR,
+    storage: &DatasetAccumulator,
+) -> Result<()> {
+    let annotations = load_node_constraint_annotations(schema_ir)?;
+
+    for node in schema_ir.node_types() {
+        if let Some(batch) = storage.get_all_nodes(&node.name)? {
+            validate_node_batch(node, &batch)?;
+        }
+    }
+
+    for edge in schema_ir.edge_types() {
+        if let Some(batch) = storage.edge_batch_for_save(&edge.name)? {
+            validate_edge_batch(edge, &batch)?;
+        }
+    }
+
+    enforce_node_key_constraints(storage, &annotations.key_props)?;
+    enforce_node_unique_constraints(storage, &annotations.unique_props)?;
+    validate_edge_endpoint_membership(schema_ir, storage)?;
+    Ok(())
+}
+
+fn validate_node_batch(node: &NodeTypeDef, batch: &RecordBatch) -> Result<()> {
+    validate_required_system_column(&node.name, "id", batch.column_by_name("id"))?;
+
+    for prop in &node.properties {
+        let column = batch.column_by_name(&prop.name).ok_or_else(|| {
+            NanoError::Storage(format!(
+                "node type {} missing property {}",
+                node.name, prop.name
+            ))
+        })?;
+        validate_property_column(&node.name, prop, column.as_ref())?;
+    }
+
+    Ok(())
+}
+
+fn validate_edge_batch(edge: &EdgeTypeDef, batch: &RecordBatch) -> Result<()> {
+    validate_required_system_column(&edge.name, "id", batch.column_by_name("id"))?;
+    validate_required_system_column(&edge.name, "src", batch.column_by_name("src"))?;
+    validate_required_system_column(&edge.name, "dst", batch.column_by_name("dst"))?;
+
+    for prop in &edge.properties {
+        let column = batch.column_by_name(&prop.name).ok_or_else(|| {
+            NanoError::Storage(format!(
+                "edge type {} missing property {}",
+                edge.name, prop.name
+            ))
+        })?;
+        validate_property_column(&edge.name, prop, column.as_ref())?;
+    }
+
+    Ok(())
+}
+
+fn validate_required_system_column(
+    type_name: &str,
+    column_name: &str,
+    column: Option<&ArrayRef>,
+) -> Result<()> {
+    let column = column.ok_or_else(|| {
+        NanoError::Storage(format!("type {} missing {} column", type_name, column_name))
+    })?;
+    if column.data_type() != &DataType::UInt64 {
+        return Err(NanoError::Storage(format!(
+            "{}.{} must be UInt64, got {:?}",
+            type_name,
+            column_name,
+            column.data_type()
+        )));
+    }
+    if column.null_count() > 0 {
+        return Err(NanoError::Storage(format!(
+            "{}.{} contains {} null value(s)",
+            type_name,
+            column_name,
+            column.null_count()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_property_column(type_name: &str, prop: &PropDef, column: &dyn Array) -> Result<()> {
+    let expected = propdef_to_arrow(prop)?;
+    if column.data_type() != &expected {
+        return Err(NanoError::Storage(format!(
+            "{}.{} has Arrow type {:?}, expected {:?}",
+            type_name,
+            prop.name,
+            column.data_type(),
+            expected
+        )));
+    }
+    if !prop.nullable && column.null_count() > 0 {
+        return Err(NanoError::Storage(format!(
+            "{}.{} contains {} null value(s) but is non-nullable",
+            type_name,
+            prop.name,
+            column.null_count()
+        )));
+    }
+    if !prop.enum_values.is_empty() {
+        validate_enum_column(type_name, &prop.name, &prop.enum_values, column)?;
+    }
+    Ok(())
+}
+
+fn validate_enum_column(
+    type_name: &str,
+    prop_name: &str,
+    enum_values: &[String],
+    column: &dyn Array,
+) -> Result<()> {
+    let allowed = enum_values
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    match column.data_type() {
+        DataType::Utf8 => {
+            let values = column
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| {
+                    NanoError::Storage(format!("{}.{} is not a Utf8 array", type_name, prop_name))
+                })?;
+            for row in 0..values.len() {
+                if values.is_null(row) {
+                    continue;
+                }
+                let value = values.value(row);
+                if !allowed.contains(value) {
+                    return Err(NanoError::Storage(format!(
+                        "invalid enum value '{}' for {}.{} on row {} (expected: {})",
+                        value,
+                        type_name,
+                        prop_name,
+                        row,
+                        enum_values.join(", ")
+                    )));
+                }
+            }
+        }
+        DataType::List(field) if field.data_type() == &DataType::Utf8 => {
+            let lists = column.as_any().downcast_ref::<ListArray>().ok_or_else(|| {
+                NanoError::Storage(format!(
+                    "{}.{} is not a List<Utf8> array",
+                    type_name, prop_name
+                ))
+            })?;
+            for row in 0..lists.len() {
+                if lists.is_null(row) {
+                    continue;
+                }
+                let items = lists.value(row);
+                let values = items
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| {
+                        NanoError::Storage(format!(
+                            "{}.{} list values are not Utf8",
+                            type_name, prop_name
+                        ))
+                    })?;
+                for item_idx in 0..values.len() {
+                    if values.is_null(item_idx) {
+                        continue;
+                    }
+                    let value = values.value(item_idx);
+                    if !allowed.contains(value) {
+                        return Err(NanoError::Storage(format!(
+                            "invalid enum value '{}' for {}.{} on row {} (expected: {})",
+                            value,
+                            type_name,
+                            prop_name,
+                            row,
+                            enum_values.join(", ")
+                        )));
+                    }
+                }
+            }
+        }
+        other => {
+            return Err(NanoError::Storage(format!(
+                "unsupported enum storage type {:?} for {}.{}",
+                other, type_name, prop_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn enforce_node_key_constraints(
+    storage: &DatasetAccumulator,
+    key_props: &HashMap<String, String>,
+) -> Result<()> {
+    for (type_name, key_prop) in key_props {
+        let Some(batch) = storage.get_all_nodes(type_name)? else {
+            continue;
+        };
+        let prop_idx = node_property_index(batch.schema().as_ref(), key_prop).ok_or_else(|| {
+            NanoError::Storage(format!(
+                "node type {} missing @key property {}",
+                type_name, key_prop
+            ))
+        })?;
+        let arr = batch.column(prop_idx);
+        for row in 0..batch.num_rows() {
+            key_value_string(arr, row, key_prop)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_edge_endpoint_membership(
+    schema_ir: &SchemaIR,
+    storage: &DatasetAccumulator,
+) -> Result<()> {
+    let mut node_ids_by_type = HashMap::new();
+    for node in schema_ir.node_types() {
+        let mut ids = HashSet::new();
+        if let Some(batch) = storage.get_all_nodes(&node.name)? {
+            let id_col = batch
+                .column_by_name("id")
+                .ok_or_else(|| NanoError::Storage(format!("node {} missing id", node.name)))?
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    NanoError::Storage(format!("node {} id column is not UInt64", node.name))
+                })?;
+            for row in 0..id_col.len() {
+                if !id_col.is_null(row) {
+                    ids.insert(id_col.value(row));
+                }
+            }
+        }
+        node_ids_by_type.insert(node.name.as_str(), ids);
+    }
+
+    for edge in schema_ir.edge_types() {
+        let Some(batch) = storage.edge_batch_for_save(&edge.name)? else {
+            continue;
+        };
+        let src_ids = batch
+            .column_by_name("src")
+            .ok_or_else(|| NanoError::Storage(format!("edge {} missing src", edge.name)))?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                NanoError::Storage(format!("edge {} src column is not UInt64", edge.name))
+            })?;
+        let dst_ids = batch
+            .column_by_name("dst")
+            .ok_or_else(|| NanoError::Storage(format!("edge {} missing dst", edge.name)))?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                NanoError::Storage(format!("edge {} dst column is not UInt64", edge.name))
+            })?;
+        let src_set = node_ids_by_type
+            .get(edge.src_type_name.as_str())
+            .ok_or_else(|| {
+                NanoError::Storage(format!(
+                    "edge {} references unknown source type {}",
+                    edge.name, edge.src_type_name
+                ))
+            })?;
+        let dst_set = node_ids_by_type
+            .get(edge.dst_type_name.as_str())
+            .ok_or_else(|| {
+                NanoError::Storage(format!(
+                    "edge {} references unknown destination type {}",
+                    edge.name, edge.dst_type_name
+                ))
+            })?;
+
+        for row in 0..batch.num_rows() {
+            if src_ids.is_null(row) || dst_ids.is_null(row) {
+                return Err(NanoError::Storage(format!(
+                    "edge {} has null endpoint on row {}",
+                    edge.name, row
+                )));
+            }
+            let src = src_ids.value(row);
+            let dst = dst_ids.value(row);
+            if !src_set.contains(&src) || !dst_set.contains(&dst) {
+                return Err(NanoError::Storage(format!(
+                    "edge {} endpoint row {} references missing node id(s): src={}, dst={}",
+                    edge.name, row, src, dst
+                )));
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -180,7 +478,7 @@ pub(crate) fn key_value_string(array: &ArrayRef, row: usize, prop_name: &str) ->
     )))
 }
 
-fn unique_value_string(
+pub(crate) fn unique_value_string(
     array: &ArrayRef,
     row: usize,
     type_name: &str,
@@ -258,6 +556,22 @@ fn scalar_value_string(
     })?;
 
     Ok(Some(value))
+}
+
+fn propdef_to_arrow(prop: &PropDef) -> Result<DataType> {
+    let scalar = ScalarType::from_str_name(&prop.scalar_type)
+        .ok_or_else(|| NanoError::Catalog(format!("unknown scalar type: {}", prop.scalar_type)))?;
+    Ok(PropType {
+        scalar,
+        nullable: prop.nullable,
+        list: prop.list,
+        enum_values: if prop.enum_values.is_empty() {
+            None
+        } else {
+            Some(prop.enum_values.clone())
+        },
+    }
+    .to_arrow())
 }
 
 #[cfg(test)]

--- a/crates/nanograph/src/store/loader/embeddings.rs
+++ b/crates/nanograph/src/store/loader/embeddings.rs
@@ -1066,9 +1066,11 @@ async fn resolve_pending_stream_batch(
                     immediate_source,
                 } => unique_media_entries.push((
                     cache_key,
-                    immediate_source
-                        .clone()
-                        .unwrap_or(media_source_from_uri(runtime.db_path, uri, mime_type)?),
+                    immediate_source.clone().unwrap_or(media_source_from_uri(
+                        runtime.db_path,
+                        uri,
+                        mime_type,
+                    )?),
                 )),
             }
         }

--- a/crates/nanograph/src/store/loader/jsonl.rs
+++ b/crates/nanograph/src/store/loader/jsonl.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Cursor, Write};
 use std::path::{Path, PathBuf};
@@ -290,8 +290,13 @@ fn flush_node_rows(
         .collect();
     let mut builders: Vec<Vec<serde_json::Value>> =
         vec![Vec::with_capacity(rows.len()); prop_fields.len()];
+    let allowed_fields = prop_fields
+        .iter()
+        .map(|field| field.name().as_str())
+        .collect::<HashSet<_>>();
 
     for row in rows.iter() {
+        reject_unknown_data_fields("node", type_name, row.row_idx, &row.data, &allowed_fields)?;
         for (idx, field) in prop_fields.iter().enumerate() {
             let value = row
                 .data
@@ -464,7 +469,7 @@ fn load_spooled_edges(
                 e
             ))
         })?;
-        let resolved = resolve_edge_object(storage, &obj, key_props, key_to_id)?;
+        let resolved = resolve_edge_object(storage, &obj, key_props, key_to_id, line_no)?;
         edges_by_pair.insert((resolved.from_id, resolved.to_id), resolved);
     }
 
@@ -546,6 +551,7 @@ fn resolve_edge_object(
     edge_obj: &serde_json::Value,
     key_props: &HashMap<String, String>,
     key_to_id: &HashMap<(String, String), u64>,
+    row_idx: usize,
 ) -> Result<ResolvedEdge> {
     let edge_type = edge_obj
         .get("edge")
@@ -631,14 +637,50 @@ fn resolve_edge_object(
             ))
         })?;
 
+    let data = match edge_obj.get("data") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::Object(data)) => Some(data.clone()),
+        Some(other) => {
+            return Err(NanoError::Storage(format!(
+                "edge {}: data must be an object on row {}, got {}",
+                edge_name,
+                row_idx,
+                describe_json_value(other)
+            )));
+        }
+    };
+    if let Some(data) = data.as_ref() {
+        let allowed_fields = et
+            .properties
+            .keys()
+            .map(String::as_str)
+            .collect::<HashSet<_>>();
+        reject_unknown_data_fields("edge", &edge_name, row_idx, data, &allowed_fields)?;
+    }
+
     Ok(ResolvedEdge {
         from_id,
         to_id,
-        data: edge_obj
-            .get("data")
-            .and_then(|value| value.as_object())
-            .cloned(),
+        data,
     })
+}
+
+fn reject_unknown_data_fields(
+    kind: &str,
+    type_name: &str,
+    row_idx: usize,
+    data: &serde_json::Map<String, serde_json::Value>,
+    allowed_fields: &HashSet<&str>,
+) -> Result<()> {
+    for key in data.keys() {
+        if !allowed_fields.contains(key.as_str()) {
+            return Err(NanoError::Storage(format!(
+                "{} {}: unknown property '{}' on row {}",
+                kind, type_name, key, row_idx
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn resolve_edge_name(storage: &DatasetAccumulator, edge_type: &str) -> Result<String> {
@@ -1656,6 +1698,48 @@ edge WorksWith: Person -> Person {
         assert_eq!(
             err.to_string(),
             r#"storage error: type mismatch for Person.age: expected I32, got String "not-a-number""#
+        );
+    }
+
+    #[test]
+    fn load_jsonl_rejects_unknown_node_properties() {
+        let schema = r#"node Person {
+    name: String @key
+}"#;
+        let mut storage = build_storage(schema);
+        let err = load_jsonl_data(
+            &mut storage,
+            r#"{"type":"Person","data":{"name":"Alice","naem":"typo"}}"#,
+            &HashMap::from([("Person".to_string(), "name".to_string())]),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown property 'naem'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_jsonl_rejects_unknown_edge_properties() {
+        let schema = r#"node Person {
+    name: String @key
+}
+edge Knows: Person -> Person {
+    since: Date?
+}"#;
+        let mut storage = build_storage(schema);
+        let data = r#"{"type":"Person","data":{"name":"Alice"}}
+{"type":"Person","data":{"name":"Bob"}}
+{"edge":"Knows","from":"Alice","to":"Bob","data":{"sicne":"2026-01-01"}}"#;
+        let err = load_jsonl_data(
+            &mut storage,
+            data,
+            &HashMap::from([("Person".to_string(), "name".to_string())]),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown property 'sicne'"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/nanograph/src/store/migration.rs
+++ b/crates/nanograph/src/store/migration.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use arrow_array::cast::AsArray;
 use arrow_array::types::UInt64Type;
 use arrow_array::{Array, ArrayRef, RecordBatch, StringArray, UInt64Array, new_null_array};
+use arrow_schema::DataType;
 use serde::{Deserialize, Serialize};
 
 use crate::catalog::Catalog;
@@ -15,9 +16,12 @@ use crate::catalog::schema_ir::{
 use crate::error::{NanoError, Result};
 use crate::schema::ast::{PropDecl, SchemaDecl, SchemaFile, annotation_value, has_annotation};
 use crate::schema::parser::parse_schema;
+use crate::store::blob_store::{
+    ManagedBlobRow, current_blob_store_entry, managed_blob_batch, read_managed_blob_bytes,
+};
 use crate::store::graph::DatasetAccumulator;
-use crate::store::graph_types::{GraphCommitRecord, GraphTableVersion, GraphTouchedTableWindow};
 use crate::store::graph_mirror::rebuild_graph_mirror_from_wal;
+use crate::store::graph_types::{GraphCommitRecord, GraphTableVersion, GraphTouchedTableWindow};
 use crate::store::indexing::{
     rebuild_node_scalar_indexes, rebuild_node_text_indexes, rebuild_node_vector_indexes,
 };
@@ -25,13 +29,17 @@ use crate::store::lance_io::{
     latest_lance_dataset_version, read_lance_batches_for_locator,
     read_lance_projected_batches_for_locator, write_lance_batch,
 };
+use crate::store::loader::{
+    key_value_string, load_node_constraint_annotations, unique_value_string,
+    validate_storage_against_schema,
+};
 use crate::store::manifest::{DatasetEntry, GraphManifest, hash_string};
 use crate::store::metadata::{DatabaseMetadata, DatasetLocator};
 use crate::store::namespace::{
     BLOB_STORE_TABLE_ID, GRAPH_CHANGES_TABLE_ID, GRAPH_DELETES_TABLE_ID, GRAPH_TX_TABLE_ID,
-    batch_publish_namespace_versions, namespace_published_version_for_table,
-    namespace_location_to_manifest_dataset_path, open_directory_namespace,
-    resolve_table_location, write_namespace_batch,
+    batch_publish_namespace_versions, namespace_location_to_manifest_dataset_path,
+    namespace_published_version_for_table, open_directory_namespace, resolve_table_location,
+    write_namespace_batch,
 };
 use crate::store::namespace_lineage_graph_log::{
     ensure_graph_deletes_table, ensure_namespace_lineage_graph_tx_table,
@@ -43,9 +51,6 @@ use crate::store::txlog::{
 };
 use crate::store::v4_graph_log::{ensure_graph_changes_table, ensure_graph_tx_table};
 use crate::types::ScalarType;
-use crate::store::blob_store::{
-    ManagedBlobRow, current_blob_store_entry, managed_blob_batch, read_managed_blob_bytes,
-};
 
 const SCHEMA_PG_FILENAME: &str = "schema.pg";
 const SCHEMA_IR_FILENAME: &str = "schema.ir.json";
@@ -469,6 +474,9 @@ async fn plan_schema_migration(
         &mut warnings,
         &mut blocked,
     )?;
+    if let Err(err) = load_node_constraint_annotations(&new_ir) {
+        blocked.push(err.to_string());
+    }
     manifest.next_type_id = next_type_id;
     manifest.next_prop_id = next_prop_id;
 
@@ -1466,6 +1474,23 @@ fn classify_enum_value_change(
     let old_values = old_prop.enum_values.iter().cloned().collect::<HashSet<_>>();
     let new_values = new_prop.enum_values.iter().cloned().collect::<HashSet<_>>();
 
+    if !old_values.is_empty() && new_values.is_empty() {
+        return (
+            SchemaCompatibility::Additive,
+            format!(
+                "enum constraint removed for `{}`.`{}`",
+                type_name, prop_name
+            ),
+            None,
+        );
+    }
+    if old_values.is_empty() && !new_values.is_empty() {
+        return (
+            SchemaCompatibility::Breaking,
+            format!("enum constraint added for `{}`.`{}`", type_name, prop_name),
+            None,
+        );
+    }
     if old_values.is_subset(&new_values) && !new_values.is_subset(&old_values) {
         return (
             SchemaCompatibility::Additive,
@@ -1759,6 +1784,30 @@ async fn diff_schema(
                         reason: "id-preserving node rename".to_string(),
                     });
                 }
+                plan_metadata_change(
+                    PlannedMetadataTarget {
+                        target_kind: "node",
+                        type_name: &new_node.name,
+                        type_id: new_node.type_id,
+                        prop: None,
+                    },
+                    "description",
+                    old_node.description.as_deref(),
+                    new_node.description.as_deref(),
+                    steps,
+                );
+                plan_metadata_change(
+                    PlannedMetadataTarget {
+                        target_kind: "node",
+                        type_name: &new_node.name,
+                        type_id: new_node.type_id,
+                        prop: None,
+                    },
+                    "instruction",
+                    old_node.instruction.as_deref(),
+                    new_node.instruction.as_deref(),
+                    steps,
+                );
                 diff_properties(
                     PropertyDiffTarget {
                         source_type_name: &old_node.name,
@@ -1817,6 +1866,30 @@ async fn diff_schema(
                         reason: "id-preserving edge rename".to_string(),
                     });
                 }
+                plan_metadata_change(
+                    PlannedMetadataTarget {
+                        target_kind: "edge",
+                        type_name: &new_edge.name,
+                        type_id: new_edge.type_id,
+                        prop: None,
+                    },
+                    "description",
+                    old_edge.description.as_deref(),
+                    new_edge.description.as_deref(),
+                    steps,
+                );
+                plan_metadata_change(
+                    PlannedMetadataTarget {
+                        target_kind: "edge",
+                        type_name: &new_edge.name,
+                        type_id: new_edge.type_id,
+                        prop: None,
+                    },
+                    "instruction",
+                    old_edge.instruction.as_deref(),
+                    new_edge.instruction.as_deref(),
+                    steps,
+                );
 
                 if old_edge.src_type_id != new_edge.src_type_id
                     || old_edge.dst_type_id != new_edge.dst_type_id
@@ -1881,6 +1954,39 @@ struct PropertyDiffTarget<'a> {
     storage_kind: PropertyStorageKind,
 }
 
+struct PlannedMetadataTarget<'a> {
+    target_kind: &'a str,
+    type_name: &'a str,
+    type_id: u32,
+    prop: Option<(&'a str, u32)>,
+}
+
+fn plan_metadata_change(
+    target: PlannedMetadataTarget<'_>,
+    annotation: &str,
+    old_value: Option<&str>,
+    new_value: Option<&str>,
+    steps: &mut Vec<PlannedStep>,
+) {
+    if old_value == new_value {
+        return;
+    }
+    let prop_name = target.prop.map(|(name, _)| name.to_string());
+    steps.push(PlannedStep {
+        step: MigrationStep::AlterMetadata {
+            target_kind: target.target_kind.to_string(),
+            type_name: target.type_name.to_string(),
+            type_id: target.type_id,
+            prop_name,
+            annotation: annotation.to_string(),
+            old_value: old_value.map(str::to_string),
+            new_value: new_value.map(str::to_string),
+        },
+        safety: MigrationSafety::Safe,
+        reason: format!("{} metadata updated", annotation),
+    });
+}
+
 async fn diff_properties(
     target: PropertyDiffTarget<'_>,
     old_props: &[PropDef],
@@ -1901,14 +2007,23 @@ async fn diff_properties(
     for new_p in new_props {
         match old_by_id.get(&new_p.prop_id) {
             None => {
-                let safety = if new_p.nullable {
-                    MigrationSafety::Safe
-                } else {
+                let existing_rows =
+                    existing_row_count(data_view, target.storage_kind, target.source_type_name)
+                        .await?;
+                let safety = if !new_p.nullable && existing_rows > 0 {
                     blocked.push(format!(
                         "type `{}` adds non-nullable property `{}` without a default/backfill",
                         target.display_type_name, new_p.name
                     ));
                     MigrationSafety::Blocked
+                } else if new_p.key && existing_rows > 0 {
+                    blocked.push(format!(
+                        "type `{}` adds @key property `{}` without a value source for {} existing row(s)",
+                        target.display_type_name, new_p.name, existing_rows
+                    ));
+                    MigrationSafety::Blocked
+                } else {
+                    MigrationSafety::Safe
                 };
                 steps.push(PlannedStep {
                     step: MigrationStep::AddProperty {
@@ -1916,7 +2031,7 @@ async fn diff_properties(
                         type_id: target.type_id,
                         prop_name: new_p.name.clone(),
                         prop_id: new_p.prop_id,
-                        data_type: new_p.scalar_type.clone(),
+                        data_type: prop_display_type(new_p),
                         nullable: new_p.nullable,
                     },
                     safety,
@@ -1937,14 +2052,52 @@ async fn diff_properties(
                         reason: "id-preserving property rename".to_string(),
                     });
                 }
-                if old_p.scalar_type != new_p.scalar_type {
+                plan_metadata_change(
+                    PlannedMetadataTarget {
+                        target_kind: "property",
+                        type_name: target.display_type_name,
+                        type_id: target.type_id,
+                        prop: Some((&new_p.name, new_p.prop_id)),
+                    },
+                    "description",
+                    old_p.description.as_deref(),
+                    new_p.description.as_deref(),
+                    steps,
+                );
+                if old_p.enum_values != new_p.enum_values {
+                    let (safety, reason) = classify_enum_change(
+                        data_view,
+                        target.storage_kind,
+                        target.source_type_name,
+                        target.display_type_name,
+                        old_p,
+                        new_p,
+                    )
+                    .await?;
+                    if safety == MigrationSafety::Blocked {
+                        blocked.push(reason.clone());
+                    }
+                    steps.push(PlannedStep {
+                        step: MigrationStep::AlterPropertyEnumValues {
+                            type_name: target.display_type_name.to_string(),
+                            type_id: target.type_id,
+                            prop_name: new_p.name.clone(),
+                            prop_id: new_p.prop_id,
+                            old_values: old_p.enum_values.clone(),
+                            new_values: new_p.enum_values.clone(),
+                        },
+                        safety,
+                        reason,
+                    });
+                }
+                if old_p.list != new_p.list || old_p.scalar_type != new_p.scalar_type {
                     let (safety, reason) = classify_type_change(
                         data_view,
                         target.storage_kind,
                         target.source_type_name,
                         target.display_type_name,
-                        &old_p.name,
-                        &new_p.scalar_type,
+                        old_p,
+                        new_p,
                     )
                     .await?;
                     if safety == MigrationSafety::Blocked {
@@ -1956,8 +2109,8 @@ async fn diff_properties(
                             type_id: target.type_id,
                             prop_name: new_p.name.clone(),
                             prop_id: new_p.prop_id,
-                            old_type: old_p.scalar_type.clone(),
-                            new_type: new_p.scalar_type.clone(),
+                            old_type: prop_display_type(old_p),
+                            new_type: prop_display_type(new_p),
                         },
                         safety,
                         reason,
@@ -1989,6 +2142,77 @@ async fn diff_properties(
                         reason,
                     });
                 }
+                if old_p.key != new_p.key {
+                    let (safety, reason) = classify_key_change(
+                        data_view,
+                        target.storage_kind,
+                        target.source_type_name,
+                        target.display_type_name,
+                        old_p,
+                        new_p,
+                    )
+                    .await?;
+                    if safety == MigrationSafety::Blocked {
+                        blocked.push(reason.clone());
+                    }
+                    steps.push(PlannedStep {
+                        step: MigrationStep::AlterPropertyKey {
+                            type_name: target.display_type_name.to_string(),
+                            type_id: target.type_id,
+                            prop_name: new_p.name.clone(),
+                            prop_id: new_p.prop_id,
+                            keyed: new_p.key,
+                        },
+                        safety,
+                        reason,
+                    });
+                }
+                if old_p.unique != new_p.unique {
+                    let (safety, reason) = classify_unique_change(
+                        data_view,
+                        target.storage_kind,
+                        target.source_type_name,
+                        target.display_type_name,
+                        old_p,
+                        new_p,
+                    )
+                    .await?;
+                    if safety == MigrationSafety::Blocked {
+                        blocked.push(reason.clone());
+                    }
+                    steps.push(PlannedStep {
+                        step: MigrationStep::AlterPropertyUnique {
+                            type_name: target.display_type_name.to_string(),
+                            type_id: target.type_id,
+                            prop_name: new_p.name.clone(),
+                            prop_id: new_p.prop_id,
+                            unique: new_p.unique,
+                        },
+                        safety,
+                        reason,
+                    });
+                }
+                if old_p.index != new_p.index {
+                    steps.push(PlannedStep {
+                        step: MigrationStep::AlterPropertyIndex {
+                            type_name: target.display_type_name.to_string(),
+                            type_id: target.type_id,
+                            prop_name: new_p.name.clone(),
+                            prop_id: new_p.prop_id,
+                            indexed: new_p.index,
+                        },
+                        safety: if new_p.index {
+                            MigrationSafety::Safe
+                        } else {
+                            MigrationSafety::Confirm
+                        },
+                        reason: if new_p.index {
+                            "index added".to_string()
+                        } else {
+                            "index removed".to_string()
+                        },
+                    });
+                }
             }
         }
     }
@@ -2016,34 +2240,318 @@ async fn classify_type_change(
     storage_kind: PropertyStorageKind,
     source_type_name: &str,
     display_type_name: &str,
-    old_prop_name: &str,
-    target_scalar: &str,
+    old_prop: &PropDef,
+    new_prop: &PropDef,
 ) -> Result<(MigrationSafety, String)> {
-    let target = ScalarType::from_str_name(target_scalar)
-        .ok_or_else(|| NanoError::Catalog(format!("unknown scalar type: {}", target_scalar)))?
-        .to_arrow();
+    if old_prop.list != new_prop.list {
+        let non_null_values = existing_non_null_value_count(
+            data_view,
+            storage_kind,
+            source_type_name,
+            &old_prop.name,
+        )
+        .await?;
+        if non_null_values == 0 {
+            return Ok((
+                MigrationSafety::Confirm,
+                "list/scalar shape changed with no existing non-null values".to_string(),
+            ));
+        }
+        return Ok((
+            MigrationSafety::Blocked,
+            format!(
+                "cannot change list/scalar shape for `{}`.`{}` with {} existing non-null value(s)",
+                display_type_name, old_prop.name, non_null_values
+            ),
+        ));
+    }
 
-    match get_property_column(data_view, storage_kind, source_type_name, old_prop_name).await? {
+    let old_scalar = ScalarType::from_str_name(&old_prop.scalar_type).ok_or_else(|| {
+        NanoError::Catalog(format!("unknown scalar type: {}", old_prop.scalar_type))
+    })?;
+    let new_scalar = ScalarType::from_str_name(&new_prop.scalar_type).ok_or_else(|| {
+        NanoError::Catalog(format!("unknown scalar type: {}", new_prop.scalar_type))
+    })?;
+    let target = propdef_to_arrow(new_prop)?;
+
+    match get_property_column(data_view, storage_kind, source_type_name, &old_prop.name).await? {
         None => Ok((
-            MigrationSafety::Confirm,
-            "type change requires data cast".to_string(),
+            MigrationSafety::Safe,
+            "type changed on empty type".to_string(),
         )),
         Some(col) => {
-            if arrow_cast::cast(col.as_ref(), &target).is_ok() {
-                Ok((
+            let non_null_values = col.len().saturating_sub(col.null_count());
+            if !is_lossless_scalar_change(old_scalar, new_scalar) {
+                if non_null_values == 0 {
+                    return Ok((
+                        MigrationSafety::Confirm,
+                        "non-lossless type change has no existing non-null values".to_string(),
+                    ));
+                }
+                return Ok((
+                    MigrationSafety::Blocked,
+                    format!(
+                        "non-lossless type change for `{}`.`{}` would rewrite {} existing non-null value(s)",
+                        display_type_name, old_prop.name, non_null_values
+                    ),
+                ));
+            }
+
+            let casted = arrow_cast::cast(col.as_ref(), &target);
+            match casted {
+                Ok(casted) if casted.null_count() == col.null_count() => Ok((
                     MigrationSafety::Confirm,
-                    "type change requires data cast".to_string(),
-                ))
-            } else {
-                Ok((
+                    "lossless type widening requires data cast".to_string(),
+                )),
+                Ok(casted) => Ok((
+                    MigrationSafety::Blocked,
+                    format!(
+                        "cannot cast `{}`.`{}` to {} without introducing nulls ({} -> {})",
+                        display_type_name,
+                        old_prop.name,
+                        prop_display_type(new_prop),
+                        col.null_count(),
+                        casted.null_count()
+                    ),
+                )),
+                Err(_) => Ok((
                     MigrationSafety::Blocked,
                     format!(
                         "cannot cast existing data for `{}`.`{}` to {}",
-                        display_type_name, old_prop_name, target_scalar
+                        display_type_name,
+                        old_prop.name,
+                        prop_display_type(new_prop)
                     ),
-                ))
+                )),
             }
         }
+    }
+}
+
+async fn classify_enum_change(
+    data_view: &mut MigrationDataView,
+    storage_kind: PropertyStorageKind,
+    source_type_name: &str,
+    display_type_name: &str,
+    old_prop: &PropDef,
+    new_prop: &PropDef,
+) -> Result<(MigrationSafety, String)> {
+    let old_values = old_prop.enum_values.iter().cloned().collect::<HashSet<_>>();
+    let new_values = new_prop.enum_values.iter().cloned().collect::<HashSet<_>>();
+
+    if !old_values.is_empty() && new_values.is_empty() {
+        return Ok((MigrationSafety::Safe, "enum constraint removed".to_string()));
+    }
+    if !old_values.is_empty() && old_values.is_subset(&new_values) {
+        return Ok((MigrationSafety::Safe, "enum domain expanded".to_string()));
+    }
+
+    let Some(col) =
+        get_property_column(data_view, storage_kind, source_type_name, &old_prop.name).await?
+    else {
+        return Ok((
+            MigrationSafety::Safe,
+            "enum domain tightened on empty type".to_string(),
+        ));
+    };
+    let invalid = count_values_outside_enum(col.as_ref(), &new_values)?;
+    if invalid > 0 {
+        return Ok((
+            MigrationSafety::Blocked,
+            format!(
+                "enum domain change for `{}`.`{}` would invalidate {} existing value(s)",
+                display_type_name, old_prop.name, invalid
+            ),
+        ));
+    }
+    Ok((
+        MigrationSafety::Confirm,
+        "enum domain tightened after data validation".to_string(),
+    ))
+}
+
+async fn classify_key_change(
+    data_view: &mut MigrationDataView,
+    storage_kind: PropertyStorageKind,
+    source_type_name: &str,
+    display_type_name: &str,
+    old_prop: &PropDef,
+    new_prop: &PropDef,
+) -> Result<(MigrationSafety, String)> {
+    if !new_prop.key {
+        return Ok((
+            MigrationSafety::Confirm,
+            "key constraint removed; identity semantics change".to_string(),
+        ));
+    }
+    if !matches!(storage_kind, PropertyStorageKind::Node) {
+        return Ok((
+            MigrationSafety::Blocked,
+            format!("only node properties can be @key: `{}`", display_type_name),
+        ));
+    }
+    let Some(col) =
+        get_property_column(data_view, storage_kind, source_type_name, &old_prop.name).await?
+    else {
+        return Ok((
+            MigrationSafety::Safe,
+            "key constraint added on empty type".to_string(),
+        ));
+    };
+    let mut seen = HashSet::new();
+    for row in 0..col.len() {
+        let value = match key_value_string(&col, row, &new_prop.name) {
+            Ok(value) => value,
+            Err(err) => {
+                return Ok((
+                    MigrationSafety::Blocked,
+                    format!(
+                        "cannot add @key to `{}`.`{}`: {}",
+                        display_type_name, new_prop.name, err
+                    ),
+                ));
+            }
+        };
+        if !seen.insert(value.clone()) {
+            return Ok((
+                MigrationSafety::Blocked,
+                format!(
+                    "cannot add @key to `{}`.`{}`: duplicate value `{}` exists",
+                    display_type_name, new_prop.name, value
+                ),
+            ));
+        }
+    }
+    Ok((
+        MigrationSafety::Confirm,
+        "key constraint added after data validation".to_string(),
+    ))
+}
+
+async fn classify_unique_change(
+    data_view: &mut MigrationDataView,
+    storage_kind: PropertyStorageKind,
+    source_type_name: &str,
+    display_type_name: &str,
+    old_prop: &PropDef,
+    new_prop: &PropDef,
+) -> Result<(MigrationSafety, String)> {
+    if !new_prop.unique {
+        return Ok((
+            MigrationSafety::Confirm,
+            "unique constraint removed".to_string(),
+        ));
+    }
+    if !matches!(storage_kind, PropertyStorageKind::Node) {
+        return Ok((
+            MigrationSafety::Blocked,
+            format!(
+                "only node properties can be @unique: `{}`",
+                display_type_name
+            ),
+        ));
+    }
+    let Some(col) =
+        get_property_column(data_view, storage_kind, source_type_name, &old_prop.name).await?
+    else {
+        return Ok((
+            MigrationSafety::Safe,
+            "unique constraint added on empty type".to_string(),
+        ));
+    };
+    let mut seen = HashSet::new();
+    for row in 0..col.len() {
+        let Some(value) = unique_value_string(&col, row, display_type_name, &new_prop.name)? else {
+            continue;
+        };
+        if !seen.insert(value.clone()) {
+            return Ok((
+                MigrationSafety::Blocked,
+                format!(
+                    "cannot add @unique to `{}`.`{}`: duplicate value `{}` exists",
+                    display_type_name, new_prop.name, value
+                ),
+            ));
+        }
+    }
+    Ok((
+        MigrationSafety::Confirm,
+        "unique constraint added after data validation".to_string(),
+    ))
+}
+
+async fn existing_non_null_value_count(
+    data_view: &mut MigrationDataView,
+    storage_kind: PropertyStorageKind,
+    source_type_name: &str,
+    prop_name: &str,
+) -> Result<usize> {
+    Ok(
+        get_property_column(data_view, storage_kind, source_type_name, prop_name)
+            .await?
+            .map(|col| col.len().saturating_sub(col.null_count()))
+            .unwrap_or(0),
+    )
+}
+
+async fn existing_row_count(
+    data_view: &mut MigrationDataView,
+    storage_kind: PropertyStorageKind,
+    source_type_name: &str,
+) -> Result<usize> {
+    let batch = match storage_kind {
+        PropertyStorageKind::Node => data_view.node_batch(source_type_name).await?,
+        PropertyStorageKind::Edge => data_view.edge_batch(source_type_name).await?,
+    };
+    Ok(batch.map(|batch| batch.num_rows()).unwrap_or(0))
+}
+
+fn count_values_outside_enum(array: &dyn Array, allowed: &HashSet<String>) -> Result<usize> {
+    match array.data_type() {
+        DataType::Utf8 => {
+            let values = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| NanoError::Storage("enum column is not Utf8".to_string()))?;
+            let mut invalid = 0usize;
+            for row in 0..values.len() {
+                if !values.is_null(row) && !allowed.contains(values.value(row)) {
+                    invalid += 1;
+                }
+            }
+            Ok(invalid)
+        }
+        DataType::List(field) if field.data_type() == &DataType::Utf8 => {
+            let lists = array
+                .as_any()
+                .downcast_ref::<arrow_array::ListArray>()
+                .ok_or_else(|| {
+                    NanoError::Storage("enum list column is not List<Utf8>".to_string())
+                })?;
+            let mut invalid = 0usize;
+            for row in 0..lists.len() {
+                if lists.is_null(row) {
+                    continue;
+                }
+                let items = lists.value(row);
+                let values = items
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| {
+                        NanoError::Storage("enum list values are not Utf8".to_string())
+                    })?;
+                for item_idx in 0..values.len() {
+                    if !values.is_null(item_idx) && !allowed.contains(values.value(item_idx)) {
+                        invalid += 1;
+                    }
+                }
+            }
+            Ok(invalid)
+        }
+        other => Err(NanoError::Storage(format!(
+            "unsupported enum storage type {:?}",
+            other
+        ))),
     }
 }
 
@@ -2586,6 +3094,7 @@ async fn transform_storage_for_new_schema(
         out.load_edge_batch(&new_edge.name, batch)?;
     }
 
+    validate_storage_against_schema(new_ir, &out)?;
     out.build_indices()?;
     Ok(out)
 }
@@ -2690,9 +3199,20 @@ fn cast_array_if_needed(col: ArrayRef, target_prop: &PropDef) -> Result<ArrayRef
     let target = propdef_to_arrow(target_prop)?;
     if col.data_type() == &target {
         Ok(col)
+    } else if col.len() == 0 {
+        Ok(new_null_array(&target, 0))
     } else {
-        arrow_cast::cast(col.as_ref(), &target)
-            .map_err(|e| NanoError::Execution(format!("cast error: {}", e)))
+        let original_nulls = col.null_count();
+        let casted = arrow_cast::cast(col.as_ref(), &target)
+            .map_err(|e| NanoError::Execution(format!("cast error: {}", e)))?;
+        if casted.null_count() > original_nulls {
+            return Err(NanoError::Execution(format!(
+                "cast to {:?} introduced {} null value(s)",
+                target,
+                casted.null_count().saturating_sub(original_nulls)
+            )));
+        }
+        Ok(casted)
     }
 }
 
@@ -2709,9 +3229,12 @@ async fn write_staged_db(
         .map_err(|e| NanoError::Manifest(format!("serialize IR error: {}", e)))?;
     match storage_generation {
         Some(generation) if generation.is_namespace_managed() => {
-            let db =
-                crate::store::database::Database::init_with_generation(path, schema_source, generation)
-                    .await?;
+            let db = crate::store::database::Database::init_with_generation(
+                path,
+                schema_source,
+                generation,
+            )
+            .await?;
             drop(db);
             std::fs::write(path.join(SCHEMA_PG_FILENAME), schema_source)?;
             std::fs::write(path.join(SCHEMA_IR_FILENAME), &ir_json)?;

--- a/crates/nanograph/src/store/mod.rs
+++ b/crates/nanograph/src/store/mod.rs
@@ -9,6 +9,8 @@ pub mod metadata;
 pub mod migration;
 pub(crate) mod namespace;
 pub(crate) mod namespace_commit;
+pub(crate) mod namespace_lineage_graph_log;
+pub(crate) mod namespace_lineage_internal;
 pub(crate) mod runtime;
 #[doc(hidden)]
 pub mod snapshot;
@@ -17,8 +19,6 @@ pub mod storage_migrate;
 pub mod txlog;
 pub(crate) mod v4_graph_log;
 pub(crate) mod v4_internal;
-pub(crate) mod namespace_lineage_graph_log;
-pub(crate) mod namespace_lineage_internal;
 
 pub use indexing::{scalar_index_name, text_index_name, vector_index_name};
 

--- a/crates/nanograph/src/store/namespace.rs
+++ b/crates/nanograph/src/store/namespace.rs
@@ -99,10 +99,7 @@ fn namespace_location_to_absolute_local_path(location: &str) -> Result<PathBuf> 
     )))
 }
 
-pub(crate) fn namespace_location_to_local_path(
-    db_dir: &Path,
-    location: &str,
-) -> Result<PathBuf> {
+pub(crate) fn namespace_location_to_local_path(db_dir: &Path, location: &str) -> Result<PathBuf> {
     if let Ok(path) = namespace_location_to_absolute_local_path(location) {
         return Ok(path);
     }
@@ -360,13 +357,12 @@ pub(crate) async fn cleanup_namespace_orphan_versions(
             namespace_latest_version(namespace, GRAPH_SNAPSHOT_TABLE_ID)
                 .await?
                 .version;
-        removed +=
-            cleanup_unpublished_manifest_versions(
-                db_path,
-                &location,
-                Some(published_snapshot_version),
-            )
-                .await?;
+        removed += cleanup_unpublished_manifest_versions(
+            db_path,
+            &location,
+            Some(published_snapshot_version),
+        )
+        .await?;
     }
     Ok(removed)
 }

--- a/crates/nanograph/src/store/namespace_commit.rs
+++ b/crates/nanograph/src/store/namespace_commit.rs
@@ -18,13 +18,11 @@ use crate::store::lance_io::{
 };
 use crate::store::manifest::{DatasetEntry, GraphManifest};
 use crate::store::namespace::{
-    GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID,
-    NamespacePublishedVersion, StagedNamespaceTable, batch_publish_namespace_versions,
-    dedup_namespace_published_versions, namespace_latest_version,
-    namespace_location_to_dataset_uri, namespace_location_to_local_path,
-    namespace_location_to_manifest_dataset_path,
-    namespace_published_version_for_table, open_directory_namespace,
-    resolve_or_declare_table_location,
+    GRAPH_CHANGES_TABLE_ID, GRAPH_SNAPSHOT_TABLE_ID, GRAPH_TX_TABLE_ID, NamespacePublishedVersion,
+    StagedNamespaceTable, batch_publish_namespace_versions, dedup_namespace_published_versions,
+    namespace_latest_version, namespace_location_to_dataset_uri, namespace_location_to_local_path,
+    namespace_location_to_manifest_dataset_path, namespace_published_version_for_table,
+    open_directory_namespace, resolve_or_declare_table_location,
 };
 use crate::store::v4_graph_log::{stage_graph_change_records, stage_graph_commit_record};
 
@@ -230,14 +228,20 @@ pub(crate) fn publish_snapshot_bundle_with_staged_entries(
     let db_dir = db_dir.to_path_buf();
     let snapshot = snapshot.clone();
     let staged_entries = staged_entries.to_vec();
-    run_namespace_commit_task("publish v4 snapshot bundle with staged entries", move || async move {
-        let bundle =
-            build_snapshot_bundle_with_staged_entries_async(&db_dir, &snapshot, &staged_entries)
-                .await?;
-        GraphCommitBundlePublisher
-            .publish_bundle_async(&db_dir, &bundle)
-            .await
-    })
+    run_namespace_commit_task(
+        "publish v4 snapshot bundle with staged entries",
+        move || async move {
+            let bundle = build_snapshot_bundle_with_staged_entries_async(
+                &db_dir,
+                &snapshot,
+                &staged_entries,
+            )
+            .await?;
+            GraphCommitBundlePublisher
+                .publish_bundle_async(&db_dir, &bundle)
+                .await
+        },
+    )
 }
 
 async fn build_graph_update_bundle_async(

--- a/crates/nanograph/src/store/namespace_lineage_graph_log.rs
+++ b/crates/nanograph/src/store/namespace_lineage_graph_log.rs
@@ -17,10 +17,11 @@ use crate::store::lance_io::{
 use crate::store::manifest::{DatasetEntry, GraphManifest};
 use crate::store::metadata::DatasetLocator;
 use crate::store::namespace::{
-    GRAPH_DELETES_TABLE_ID, GRAPH_TX_TABLE_ID, StagedNamespaceTable, namespace_published_version_for_table,
+    GRAPH_DELETES_TABLE_ID, GRAPH_TX_TABLE_ID, StagedNamespaceTable,
     namespace_location_to_dataset_uri, namespace_location_to_local_path,
-    namespace_location_to_manifest_dataset_path, open_directory_namespace,
-    resolve_or_declare_table_location, resolve_table_location, write_namespace_batch,
+    namespace_location_to_manifest_dataset_path, namespace_published_version_for_table,
+    open_directory_namespace, resolve_or_declare_table_location, resolve_table_location,
+    write_namespace_batch,
 };
 
 fn manifest_dataset_path(db_path: &Path, location: &str, fallback: &str) -> Result<String> {
@@ -120,8 +121,8 @@ pub(crate) async fn stage_namespace_lineage_graph_commit_record(
     let table_id = GRAPH_TX_TABLE_ID;
     let batch = namespace_lineage_graph_commit_records_to_batch(std::slice::from_ref(record))?
         .ok_or_else(|| {
-        NanoError::Storage("graph tx append expected at least one record".to_string())
-    })?;
+            NanoError::Storage("graph tx append expected at least one record".to_string())
+        })?;
     let pinned_version = manifest
         .datasets
         .iter()
@@ -469,12 +470,7 @@ fn namespace_lineage_graph_commit_records_to_batch(
         ],
     )
     .map(Some)
-    .map_err(|err| {
-        NanoError::Storage(format!(
-            "build namespace-lineage graph tx batch: {}",
-            err
-        ))
-    })
+    .map_err(|err| NanoError::Storage(format!("build namespace-lineage graph tx batch: {}", err)))
 }
 
 fn graph_delete_records_to_batch(records: &[GraphDeleteRecord]) -> Result<Option<RecordBatch>> {
@@ -518,7 +514,12 @@ fn graph_delete_records_to_batch(records: &[GraphDeleteRecord]) -> Result<Option
             .map(|record| record.table_id.as_str().to_string())
             .collect::<Vec<_>>(),
     );
-    let rowid = UInt64Array::from(records.iter().map(|record| record.rowid).collect::<Vec<_>>());
+    let rowid = UInt64Array::from(
+        records
+            .iter()
+            .map(|record| record.rowid)
+            .collect::<Vec<_>>(),
+    );
     let entity_id = UInt64Array::from(
         records
             .iter()
@@ -595,12 +596,13 @@ fn namespace_lineage_graph_commit_records_from_batch(
 
     let mut out = Vec::with_capacity(batch.num_rows());
     for row in 0..batch.num_rows() {
-        let table_versions = serde_json::from_str(table_versions_json.value(row)).map_err(|err| {
-            NanoError::Manifest(format!(
-                "parse namespace-lineage graph tx table_versions_json error: {}",
-                err
-            ))
-        })?;
+        let table_versions =
+            serde_json::from_str(table_versions_json.value(row)).map_err(|err| {
+                NanoError::Manifest(format!(
+                    "parse namespace-lineage graph tx table_versions_json error: {}",
+                    err
+                ))
+            })?;
         let touched_tables: Vec<GraphTouchedTableWindow> =
             serde_json::from_str(touched_tables_json.value(row)).map_err(|err| {
                 NanoError::Manifest(format!(

--- a/crates/nanograph/src/store/storage_migrate.rs
+++ b/crates/nanograph/src/store/storage_migrate.rs
@@ -20,8 +20,8 @@ use crate::store::lance_io::{latest_lance_dataset_version, read_lance_batches_fo
 use crate::store::manifest::DatasetEntry;
 use crate::store::metadata::DatabaseMetadata;
 use crate::store::namespace::{
-    namespace_location_to_manifest_dataset_path, open_directory_namespace,
-    resolve_table_location, write_namespace_batch,
+    namespace_location_to_manifest_dataset_path, open_directory_namespace, resolve_table_location,
+    write_namespace_batch,
 };
 use crate::store::namespace_lineage_internal::merge_namespace_lineage_internal_dataset_entries;
 use crate::store::snapshot::read_committed_graph_snapshot;
@@ -239,8 +239,12 @@ pub async fn migrate_storage_to_lineage_native(db_path: &Path) -> Result<Storage
         let node_table_count = source.schema_ir().node_types().count();
         let edge_table_count = source.schema_ir().edge_types().count();
 
-        Database::init_with_generation(db_path, &schema_source, StorageGeneration::NamespaceLineage)
-            .await?;
+        Database::init_with_generation(
+            db_path,
+            &schema_source,
+            StorageGeneration::NamespaceLineage,
+        )
+        .await?;
 
         let mut dataset_entries = Vec::new();
         let mut media_uris_rewritten = 0usize;

--- a/crates/nanograph/src/store/txlog.rs
+++ b/crates/nanograph/src/store/txlog.rs
@@ -587,7 +587,9 @@ fn collect_namespace_lineage_change_rows_internal(
             let mut out = Vec::new();
             for commit in &commits {
                 for window in &commit.touched_tables {
-                    let entry = if let Some(entry) = data_entries_by_table_id.get(window.table_id.as_str()) {
+                    let entry = if let Some(entry) =
+                        data_entries_by_table_id.get(window.table_id.as_str())
+                    {
                         entry.clone()
                     } else {
                         let namespace = open_directory_namespace(&db_dir).await?;
@@ -609,7 +611,11 @@ fn collect_namespace_lineage_change_rows_internal(
                     );
                 }
                 if let Some(rows) = delete_map.get(&commit.graph_version.value()) {
-                    out.extend(rows.iter().cloned().map(namespace_lineage_delete_to_internal_change));
+                    out.extend(
+                        rows.iter()
+                            .cloned()
+                            .map(namespace_lineage_delete_to_internal_change),
+                    );
                 }
             }
             sort_namespace_lineage_internal_change_rows(&mut out);
@@ -648,14 +654,8 @@ async fn collect_namespace_lineage_rows_for_window(
         BTreeMap::new()
     };
 
-    let mut inserts = actual
-        .inserts
-        .into_iter()
-        .collect::<BTreeMap<u64, u64>>();
-    let mut updates = actual
-        .updates
-        .into_iter()
-        .collect::<BTreeMap<u64, u64>>();
+    let mut inserts = actual.inserts.into_iter().collect::<BTreeMap<u64, u64>>();
+    let mut updates = actual.updates.into_iter().collect::<BTreeMap<u64, u64>>();
 
     for (entity_id, rowid) in inserts.clone() {
         if previous_rows.contains_key(&entity_id) {
@@ -818,9 +818,7 @@ fn namespace_lineage_logical_key(
     format!("id={}", entity_id)
 }
 
-fn sort_namespace_lineage_internal_change_rows(
-    rows: &mut [NamespaceLineageInternalChangeRow],
-) {
+fn sort_namespace_lineage_internal_change_rows(rows: &mut [NamespaceLineageInternalChangeRow]) {
     rows.sort_by(|a, b| {
         a.visible
             .graph_version
@@ -1029,11 +1027,10 @@ pub(crate) fn commit_graph_records_and_manifest_namespace_lineage(
                 ))
             })?;
         runtime.block_on(async move {
-            let mut staged_entries =
-                vec![
-                    stage_namespace_lineage_graph_commit_record(&db_dir, &manifest, &graph_commit)
-                        .await?,
-                ];
+            let mut staged_entries = vec![
+                stage_namespace_lineage_graph_commit_record(&db_dir, &manifest, &graph_commit)
+                    .await?,
+            ];
             if !graph_deletes.is_empty() {
                 staged_entries
                     .push(stage_graph_delete_records(&db_dir, &manifest, &graph_deletes).await?);

--- a/crates/nanograph/tests/schema_migration.rs
+++ b/crates/nanograph/tests/schema_migration.rs
@@ -151,6 +151,71 @@ edge Knows: User -> User
 "#
 }
 
+fn schema_with_added_unique_email() -> &'static str {
+    r#"
+node User {
+    name: String @key
+    email: String @unique
+}
+"#
+}
+
+fn schema_without_unique_email() -> &'static str {
+    r#"
+node User {
+    name: String @key
+    email: String
+}
+"#
+}
+
+fn duplicate_email_data() -> &'static str {
+    r#"
+{"type":"User","data":{"name":"Alice","email":"dupe@example.com"}}
+{"type":"User","data":{"name":"Bob","email":"dupe@example.com"}}
+"#
+}
+
+fn schema_with_role_enum() -> &'static str {
+    r#"
+node User {
+    name: String @key
+    role: enum(admin, member, guest)
+}
+"#
+}
+
+fn schema_with_narrowed_role_enum() -> &'static str {
+    r#"
+node User {
+    name: String @key
+    role: enum(admin, member)
+}
+"#
+}
+
+fn role_enum_data_with_guest() -> &'static str {
+    r#"
+{"type":"User","data":{"name":"Alice","role":"guest"}}
+"#
+}
+
+fn schema_with_added_email_key() -> &'static str {
+    r#"
+node User {
+    name: String
+    email: String? @key
+}
+"#
+}
+
+fn nullable_email_data() -> &'static str {
+    r#"
+{"type":"User","data":{"name":"Alice","email":null}}
+{"type":"User","data":{"name":"Bob","email":"bob@example.com"}}
+"#
+}
+
 fn drop_type_base_schema() -> &'static str {
     r#"
 node User {
@@ -529,7 +594,7 @@ async fn migration_blocks_invalid_type_cast() {
         .await
         .expect("dry run");
 
-    assert_eq!(exec.status, MigrationStatus::NeedsConfirmation);
+    assert_eq!(exec.status, MigrationStatus::Blocked);
     assert!(
         exec.plan.steps.iter().any(|s| {
             matches!(
@@ -543,7 +608,14 @@ async fn migration_blocks_invalid_type_cast() {
         }),
         "expected AlterPropertyType step for User.name"
     );
-    assert!(exec.plan.blocked.is_empty());
+    assert!(
+        exec.plan
+            .blocked
+            .iter()
+            .any(|r| r.contains("non-lossless type change")),
+        "expected blocked reason for non-lossless type change: {:?}",
+        exec.plan.blocked
+    );
 }
 
 #[tokio::test]
@@ -576,6 +648,118 @@ async fn migration_blocks_nullable_to_non_nullable_when_nulls_exist() {
             .iter()
             .any(|r| r.contains("non-nullable") && r.contains("null value")),
         "expected blocked reason for existing nulls"
+    );
+}
+
+#[tokio::test]
+async fn migration_blocks_added_unique_constraint_with_duplicate_existing_values() {
+    let (_dir, db_path) =
+        init_db_with_custom_data(schema_without_unique_email(), duplicate_email_data()).await;
+    write_schema(&db_path, schema_with_added_unique_email());
+
+    let exec = execute_schema_migration(&db_path, None, true, false)
+        .await
+        .expect("dry run");
+
+    assert_eq!(exec.status, MigrationStatus::Blocked);
+    assert!(
+        exec.plan.steps.iter().any(|s| {
+            matches!(
+                s.step,
+                MigrationStep::AlterPropertyUnique {
+                    ref type_name,
+                    ref prop_name,
+                    unique,
+                    ..
+                } if type_name == "User" && prop_name == "email" && unique
+            )
+        }),
+        "expected AlterPropertyUnique step for User.email"
+    );
+    assert!(
+        exec.plan
+            .blocked
+            .iter()
+            .any(|r| r.contains("duplicate value `dupe@example.com`")),
+        "expected duplicate unique blocked reason: {:?}",
+        exec.plan.blocked
+    );
+}
+
+#[tokio::test]
+async fn migration_blocks_enum_narrowing_with_invalid_existing_values() {
+    let (_dir, db_path) =
+        init_db_with_custom_data(schema_with_role_enum(), role_enum_data_with_guest()).await;
+    write_schema(&db_path, schema_with_narrowed_role_enum());
+
+    let exec = execute_schema_migration(&db_path, None, true, false)
+        .await
+        .expect("dry run");
+
+    assert_eq!(exec.status, MigrationStatus::Blocked);
+    assert!(
+        exec.plan.steps.iter().any(|s| {
+            matches!(
+                s.step,
+                MigrationStep::AlterPropertyEnumValues {
+                    ref type_name,
+                    ref prop_name,
+                    ..
+                } if type_name == "User" && prop_name == "role"
+            )
+        }),
+        "expected AlterPropertyEnumValues step for User.role"
+    );
+    assert!(
+        exec.plan
+            .blocked
+            .iter()
+            .any(|r| r.contains("enum domain change") && r.contains("invalidate")),
+        "expected enum blocked reason: {:?}",
+        exec.plan.blocked
+    );
+}
+
+#[tokio::test]
+async fn migration_blocks_added_key_with_existing_null_values() {
+    let (_dir, db_path) = init_db_with_custom_data(
+        r#"
+node User {
+    name: String
+    email: String?
+}
+"#,
+        nullable_email_data(),
+    )
+    .await;
+    write_schema(&db_path, schema_with_added_email_key());
+
+    let exec = execute_schema_migration(&db_path, None, true, false)
+        .await
+        .expect("dry run");
+
+    assert_eq!(exec.status, MigrationStatus::Blocked);
+    assert!(
+        exec.plan.steps.iter().any(|s| {
+            matches!(
+                s.step,
+                MigrationStep::AlterPropertyKey {
+                    ref type_name,
+                    ref prop_name,
+                    keyed,
+                    ..
+                } if type_name == "User" && prop_name == "email" && keyed
+            )
+        }),
+        "expected AlterPropertyKey step for User.email"
+    );
+    assert!(
+        exec.plan
+            .blocked
+            .iter()
+            .any(|r| r.contains("cannot add @key") && r.contains("cannot be null")),
+        "expected key null blocked reason: {:?}",
+        exec.plan.blocked
     );
 }
 
@@ -681,7 +865,7 @@ async fn migration_preserves_index_annotations_in_schema_ir() {
     let (_dir, db_path) = init_db_with_data(base_schema()).await;
     write_schema(&db_path, schema_with_index_annotation());
 
-    let exec = execute_schema_migration(&db_path, None, false, false)
+    let exec = execute_schema_migration(&db_path, None, false, true)
         .await
         .expect("apply migration");
     assert_eq!(exec.status, MigrationStatus::Applied);
@@ -727,7 +911,7 @@ async fn migration_builds_scalar_indexes_for_indexed_properties() {
     let (_dir, db_path) = init_db_with_data(base_schema()).await;
     write_schema(&db_path, schema_with_index_annotation());
 
-    let exec = execute_schema_migration(&db_path, None, false, false)
+    let exec = execute_schema_migration(&db_path, None, false, true)
         .await
         .expect("apply migration");
     assert_eq!(exec.status, MigrationStatus::Applied);
@@ -785,7 +969,7 @@ async fn migration_bootstraps_identity_counters_from_legacy_manifest() {
         &db_path,
         r#"
 node User {
-    name: String
+    name: String @key
     age: I32?
 }
 node Team {

--- a/docs/dev/release-notes-v1.2.2.md
+++ b/docs/dev/release-notes-v1.2.2.md
@@ -1,0 +1,30 @@
+v1.2.2
+
+- Patch release for the `NamespaceLineage` line. `v1.2.2` fixes two query-engine bugs caught in the wild and tightens schema-migration and JSONL-load validation so unsafe changes fail fast with clear errors instead of corrupting state.
+
+- Static rejection of unsupported `nearest()` query shapes (#9):
+  - `nearest($vec, $node.prop)` and `nearest($vec, $bound_var)` previously parsed and lint-passed but failed at execution with `nearest() query must be a Vector or String literal/parameter`
+  - the typechecker now rejects these shapes with a T15 error explaining why and pointing at the workaround (fetch the value in a prior query and pass it as `$param`)
+  - per-row evaluation isn't viable because the query vector must be resolved once before scoring
+
+- Fan-in traversals to a shared destination no longer crash at execution (#8):
+  - two edges landing on the same already-bound destination (e.g. `$a aToB $b` + `$c cToB $b`) used to fail with `Arrow error: Invalid argument error: number of columns(N) must match number of fields(M) in schema`
+  - same bug fired when a `not { }` clause traversed into an outer-bound variable, since AntiJoin merges schemas
+  - the cycle-closing lowerer now threads a counter through pipeline construction and emits a unique `__temp_{dst}_{n}` per traversal, eliminating the schema collision
+
+- Schema migration now validates against stored data before applying:
+  - migrations that would introduce constraint violations are `Blocked` with a detailed error instead of silently proceeding — this covers adding `@key` on a column with nulls or duplicates, adding `@unique` on a column with duplicates, narrowing an enum to exclude existing values, and most type casts
+  - metadata-only changes (description, instruction) auto-apply as `Safe`
+  - additive vs breaking vs blocked classification is surfaced in dry-run output
+
+- JSONL loader rejects unknown property names with row numbers:
+  - typos like `"naem"` no longer silently drop the field — the loader returns a row-numbered error pointing at the offending property
+  - list-typed enum properties also have their values validated per element
+
+- Test coverage:
+  - new typecheck tests for both rejected `nearest()` shapes
+  - new engine integration tests for fan-in (two edges → same destination) and the `not { }` variant, including an orphan-detection case after a follow-up load
+  - new schema-migration tests for each blocking scenario (key-with-nulls, unique-with-duplicates, enum-narrowing-with-invalid-values, blocked type cast)
+
+- Release metadata updated:
+  - version bumped to `1.2.2` across Rust crates, npm package metadata, and Swift packaging examples

--- a/tools/swift-package/render_package.sh
+++ b/tools/swift-package/render_package.sh
@@ -9,13 +9,13 @@ Usage:
 Examples:
   render_package.sh \
     --output /tmp/nanograph-swift \
-    --version 1.2.1 \
+    --version 1.2.2 \
     --artifact-url https://example.com/NanoGraphFFI.xcframework.zip \
     --checksum abcdef123456
 
   render_package.sh \
     --output /tmp/nanograph-swift \
-    --version 1.2.1 \
+    --version 1.2.2 \
     --artifact-path /tmp/NanoGraphFFI.xcframework
 EOF
 }


### PR DESCRIPTION
## Summary

Patch release for the v1.2.x line. Bundles:

- **#9** (`5d6cbcf`, already on main): typecheck rejects `nearest($vec, $node.prop)` and bound-variable query arguments with a T15 error instead of failing at execution.
- **#8** (`5d6cbcf`, already on main): cycle-closing lowering threads a counter so each emitted temp var is unique, fixing fan-in (`$a aToB $b` + `$c cToB $b`) and the `not { }` variant that previously crashed with an Arrow column-count mismatch.
- **`feat:` (`7d17b1e`)** schema migration now validates constraint changes against stored data and blocks unsafe transitions (added `@key` with nulls/dupes, added `@unique` with dupes, enum narrowing that drops live values, most type casts) with detailed errors instead of corrupting state. JSONL loader rejects unknown property names with row-numbered errors. Tests cover each blocking scenario.
- **`release:` (`4da73e2`)** version bump 1.2.1 → 1.2.2 across `nanograph`, `nanograph-cli`, `nanograph-ffi`, `nanograph-ts` (incl. cross-refs), `nanograph-ts/package.json`, Swift packaging example, and `Cargo.lock`. Release notes added at `docs/dev/release-notes-v1.2.2.md`.

## Test plan

- [x] `cargo build -p nanograph -p nanograph-cli -p nanograph-ffi -p nanograph-ts` — green
- [x] `cargo test -p nanograph` — 355 unit + 40 integration + 25 migration, all passing
- [x] `cargo test -p nanograph --test schema_migration` — 25 tests pass (covers the new validation paths)
- [x] `cargo clippy -p nanograph --tests` — no new warnings
- [ ] CI green on `release/v1.2.2` (Core Rust, CLI E2E, TypeScript SDK, Swift SDK)
- [ ] After merge: tag `v1.2.2` on `main` and push to trigger the release workflow (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)