### PR TITLE
ci: add Publish Crates workflow for crates.io releases

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,112 @@
+name: Publish Crates
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run cargo publish with --dry-run (no upload)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: '27.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.94.1 --profile minimal
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: publish-${{ hashFiles('Cargo.lock') }}
+          restore-keys: publish-
+
+      - name: Resolve crate version
+        id: version
+        run: |
+          version=$(grep -m1 '^version' crates/nanograph/Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify all crates match version
+        run: |
+          expected="${{ steps.version.outputs.version }}"
+          for crate in crates/nanograph crates/nanograph-cli crates/nanograph-ffi crates/nanograph-ts; do
+            actual=$(grep -m1 '^version' "$crate/Cargo.toml" | sed -E 's/version = "(.*)"/\1/')
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::$crate has version $actual, expected $expected"
+              exit 1
+            fi
+          done
+
+      - name: Verify version matches tag
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          expected="${{ steps.version.outputs.version }}"
+          if [ "$tag" != "$expected" ]; then
+            echo "::error::tag $tag does not match crate version $expected"
+            exit 1
+          fi
+
+      - name: Set publish flags
+        id: flags
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            echo "args=--dry-run" >> "$GITHUB_OUTPUT"
+          else
+            echo "args=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish nanograph
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p nanograph ${{ steps.flags.outputs.args }}
+
+      - name: Wait for nanograph to appear in the crates.io index
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          for i in $(seq 1 60); do
+            if curl -fsS "https://crates.io/api/v1/crates/nanograph/$version" >/dev/null 2>&1; then
+              echo "nanograph $version visible on crates.io"
+              exit 0
+            fi
+            echo "Waiting for nanograph $version on crates.io (attempt $i/60)..."
+            sleep 5
+          done
+          echo "::error::Timed out waiting for nanograph $version on crates.io"
+          exit 1
+
+      - name: Publish nanograph-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p nanograph-cli ${{ steps.flags.outputs.args }}
+
+      - name: Publish nanograph-ffi
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p nanograph-ffi ${{ steps.flags.outputs.args }}
+
+      - name: Publish nanograph-ts
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p nanograph-ts ${{ steps.flags.outputs.args }}

--- a/docs/dev/release-checklist.md
+++ b/docs/dev/release-checklist.md
@@ -13,7 +13,8 @@
   - render + smoke test of a publishable Swift package from monorepo sources on `macos-14`
   - GitHub Release creation on Blacksmith Linux
   - Homebrew tap update dispatch on Blacksmith Linux
-- `Release` does **not** currently publish crates.io packages, npm, or an external `nanograph-swift` repo. Those remain manual.
+- `Publish Crates` runs on tag pushes (and supports `workflow_dispatch` for manual / dry-run triggers) via [publish-crates.yml](/Users/andrew/code/nanograph/.github/workflows/publish-crates.yml). It publishes `nanograph` first, waits for the crates.io index to surface the new version, then publishes `nanograph-cli`, `nanograph-ffi`, and `nanograph-ts`. Requires the `CARGO_REGISTRY_TOKEN` repo secret.
+- `Release` does **not** currently publish npm or update the external `nanograph-swift` repo. Those remain manual.
 
 ## Pre-release
 
@@ -61,16 +62,26 @@ This automatically:
 - Creates GitHub Release with `nanograph-vX.Y.Z-aarch64-apple-darwin.tar.gz` + `.sha256` on Blacksmith Linux
 - Dispatches formula update to `nanograph/homebrew-tap` on Blacksmith Linux
 
-### 2. crates.io (publish `nanograph` first, then the dependents)
+### 2. crates.io
+
+Automated by the `Publish Crates` workflow on tag push. It publishes `nanograph` first, polls the crates.io index until the new version is visible, then publishes `nanograph-cli`, `nanograph-ffi`, and `nanograph-ts`.
+
+To dry-run or re-trigger manually:
+
+```bash
+gh workflow run publish-crates.yml -f dry_run=true   # dry run, no upload
+gh workflow run publish-crates.yml                   # real publish from current main
+```
+
+If you ever need to fall back to manual:
 
 ```bash
 cargo publish -p nanograph
+# wait for the new version to be searchable on crates.io
 cargo publish -p nanograph-cli
 cargo publish -p nanograph-ffi
 cargo publish -p nanograph-ts
 ```
-
-Wait for the new `nanograph` version to become visible in the crates.io index before publishing `nanograph-cli`, `nanograph-ffi`, and `nanograph-ts`.
 
 ### 3. npm
 


### PR DESCRIPTION
## Summary

Automates the manual `cargo publish` sequence from the release checklist into a GitHub Actions workflow.

- Triggers: tag push matching `v*`, plus `workflow_dispatch` with an optional `dry_run` input.
- Reads the API token from the `CARGO_REGISTRY_TOKEN` repo secret (already configured).
- Verifies all four crate manifests share a single version, and (on tag push) that version matches the tag — fails fast if not.
- Publishes `nanograph` first, then polls the crates.io HTTP API until the new version is indexed, then publishes `nanograph-cli`, `nanograph-ffi`, `nanograph-ts`.
- Release checklist updated to point at the new workflow; the manual `cargo publish` sequence is retained as a documented fallback.

## Test plan

- [ ] CI green on this PR (workflow file syntax / yaml parse)
- [ ] After merge, run `gh workflow run publish-crates.yml -f dry_run=true` from `main` to validate the workflow without uploading
- [ ] Real publish for `v1.2.2` will require either re-tagging or a manual `gh workflow run publish-crates.yml` since the v1.2.2 tag was pushed before this workflow existed
- [ ] Future `vX.Y.Z` tag pushes should fire `Publish Crates` alongside `Release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)