### PR TITLE
ci: use crates.io sparse index for publish-status checks

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -71,9 +71,23 @@ jobs:
         id: check
         run: |
           version="${{ steps.version.outputs.version }}"
+          # Use the sparse index (what cargo itself reads) instead of the
+          # crates.io HTTP API. The HTTP API rejects requests without a
+          # User-Agent header from cloud IPs (returns 403), while the sparse
+          # index is CDN-served and has no such restriction.
+          index_path() {
+            local c="$1"
+            case ${#c} in
+              1) echo "1/$c" ;;
+              2) echo "2/$c" ;;
+              3) echo "3/${c:0:1}/$c" ;;
+              *) echo "${c:0:2}/${c:2:2}/$c" ;;
+            esac
+          }
           for crate in nanograph nanograph-cli nanograph-ffi nanograph-ts; do
             key=$(echo "$crate" | tr - _)
-            if curl -fsS "https://crates.io/api/v1/crates/$crate/$version" >/dev/null 2>&1; then
+            url="https://index.crates.io/$(index_path "$crate")"
+            if curl -fsS "$url" 2>/dev/null | grep -q "\"vers\":\"$version\""; then
               echo "${key}=true" >> "$GITHUB_OUTPUT"
               echo "$crate $version is already on crates.io — will skip"
             else
@@ -101,10 +115,11 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         run: |
           version="${{ steps.version.outputs.version }}"
-          # crates.io index propagation can take 10+ minutes after publish.
+          # Sparse-index URL — same rationale as the check step above.
           # 240 × 5s = 20 min budget; exits early once visible.
           for i in $(seq 1 240); do
-            if curl -fsS "https://crates.io/api/v1/crates/nanograph/$version" >/dev/null 2>&1; then
+            if curl -fsS "https://index.crates.io/na/no/nanograph" 2>/dev/null \
+                | grep -q "\"vers\":\"$version\""; then
               echo "nanograph $version visible on crates.io"
               exit 0
             fi


### PR DESCRIPTION
## Summary

Follow-up to #13. The first re-run after #13 merged still failed at \`Publish nanograph\`: the \"already published?\" check returned false even though \`nanograph 1.2.2\` was on crates.io. Root cause: the crates.io HTTP API (\`api.crates.io\`) returns 403 to requests without a User-Agent header from cloud-provider IPs. Locally curl sends a default UA so it works; on the GitHub Actions runner it doesn't.

Switching to the **sparse index** at \`index.crates.io\` — the canonical metadata source cargo itself reads, CDN-served, no UA requirement. The check now greps the line-delimited JSON for \`\"vers\":\"X.Y.Z\"\`. The post-publish wait loop uses the same source.

Path layout follows cargo's convention (1/2/3-char prefixes), implemented as a small bash helper.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, run the publish workflow and confirm:
  - check correctly reports \`nanograph 1.2.2\` already-published, skips its publish step
  - the wait step exits immediately
  - the three dependents publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)