### PR TITLE
ci: fix Publish NPM windows build and unblock darwin-x64

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,7 +28,7 @@ jobs:
             target: aarch64-apple-darwin
             binary: nanograph.darwin-arm64.node
           - name: darwin-x64
-            runner: macos-13
+            runner: macos-14
             target: x86_64-apple-darwin
             binary: nanograph.darwin-x64.node
           - name: linux-x64-gnu
@@ -73,7 +73,13 @@ jobs:
 
       - name: Install npm deps
         working-directory: crates/nanograph-ts
-        run: npm install
+        # --ignore-scripts skips the package's own `install` lifecycle hook
+        # (scripts/install.cjs), which is meant for end-user installs and
+        # tries to rebuild the .node when a bundled binary is missing — its
+        # Windows fallback path is broken (execFileSync of `napi.cmd` returns
+        # EINVAL) and its Linux/macOS path would do redundant work since we
+        # build explicitly in the next step.
+        run: npm install --ignore-scripts
 
       - name: Build .node binary
         working-directory: crates/nanograph-ts


### PR DESCRIPTION
## Summary

Follow-up to #15. First dry-run surfaced two issues:

1. **Windows build failed in \`npm install\`.** The package's \`install\` lifecycle hook (\`scripts/install.cjs\`) tries to rebuild the \`.node\` when no bundled binary exists, and its Windows fallback path is \`execFileSync('napi.cmd', ...)\` — Node's \`execFileSync\` can't invoke \`.cmd\` files without \`shell: true\`, so it errors with \`EINVAL\`. Adding \`--ignore-scripts\` to the CI install skips the hook, which is meant for end-user installs anyway (we build explicitly right after).
2. **\`darwin-x64\` sat in the \`macos-13\` runner queue indefinitely.** Switched to \`macos-14\` with cross-compile via the existing \`rustup ... --target x86_64-apple-darwin\` step. Apple Silicon includes the x86_64 SDK so this works natively without extra setup.

The install.cjs Windows bug also breaks end-user installs on Windows when no bundled binary is present. That's a separate fix worth doing later — for CI we don't want the hook to fire at all.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: \`gh workflow run publish-npm.yml -f dry_run=true\` finishes all 5 build jobs successfully and reaches the publish job

🤖 Generated with [Claude Code](https://claude.com/claude-code)