### PR TITLE
feat: agent-toolbelt mutations (put, where-block CAS, matched_nodes)

### DIFF
--- a/crates/nanograph-cli/src/main.rs
+++ b/crates/nanograph-cli/src/main.rs
@@ -1968,7 +1968,7 @@ fn collect_type_mutation_coverage(
                     );
                 }
             }
-            Mutation::Insert(_) | Mutation::Delete(_) => {}
+            Mutation::Insert(_) | Mutation::Put(_) | Mutation::Delete(_) => {}
         }
     }
 
@@ -2094,6 +2094,13 @@ fn query_is_sparse_mutation_eligible(query: &QueryDecl, metadata: &DatabaseMetad
                     .catalog()
                     .edge_types
                     .contains_key(&insert.type_name)
+        }
+        Some(nanograph::query::ast::Mutation::Put(_)) => {
+            // Put routes through Database::open + execute_put_mutation, which
+            // dispatches to apply_merge_mutation_locked. The sparse path doesn't
+            // (yet) replicate that machinery in a single-row form.
+            let _ = metadata;
+            false
         }
         Some(nanograph::query::ast::Mutation::Update(update)) => {
             metadata

--- a/crates/nanograph-cli/src/main.rs
+++ b/crates/nanograph-cli/src/main.rs
@@ -3285,11 +3285,7 @@ fn parse_delete_predicate(input: &str) -> Result<DeletePredicate> {
 
             let value = strip_matching_quotes(raw_value).to_string();
 
-            return Ok(DeletePredicate {
-                property: property.to_string(),
-                op,
-                value,
-            });
+            return Ok(DeletePredicate::compare(property.to_string(), op, value));
         }
     }
 

--- a/crates/nanograph-cli/src/tests.rs
+++ b/crates/nanograph-cli/src/tests.rs
@@ -804,9 +804,19 @@ fn parse_param_single_quote_value_does_not_panic() {
 #[test]
 fn parse_delete_predicate_single_quote_value_does_not_panic() {
     let pred = parse_delete_predicate("slug='").unwrap();
-    assert_eq!(pred.property, "slug");
-    assert_eq!(pred.op, DeleteOp::Eq);
-    assert_eq!(pred.value, "'");
+    assert_eq!(pred.atoms.len(), 1);
+    match &pred.atoms[0] {
+        nanograph::store::database::DeletePredAtom::Compare {
+            property,
+            op,
+            value,
+        } => {
+            assert_eq!(property, "slug");
+            assert_eq!(*op, DeleteOp::Eq);
+            assert_eq!(value, "'");
+        }
+        other => panic!("expected Compare atom, got {:?}", other),
+    }
 }
 
 #[test]

--- a/crates/nanograph-cli/tests/mutation_toolbelt.rs
+++ b/crates/nanograph-cli/tests/mutation_toolbelt.rs
@@ -1,0 +1,210 @@
+mod common;
+
+use common::{ExampleProject, ExampleWorkspace, scalar_string};
+
+fn toolbelt_schema() -> &'static str {
+    r#"
+node Issue {
+    slug: String @key
+    title: String
+    status: enum(open, in_progress, closed)
+    claimedBy: String?
+    updatedAt: DateTime
+}
+"#
+}
+
+fn toolbelt_queries() -> &'static str {
+    r#"
+query ensure_issue($slug: String, $title: String) {
+    put Issue {
+        slug: $slug,
+        title: $title,
+        status: "open",
+        updatedAt: now()
+    }
+}
+
+query claim_issue($slug: String, $agent: String) {
+    update Issue set {
+        claimedBy: $agent,
+        status: "in_progress",
+        updatedAt: now()
+    } where {
+        slug = $slug
+        claimedBy is null
+    }
+}
+
+query inspect($slug: String) {
+    match { $i: Issue { slug: $slug } }
+    return { $i.slug, $i.status, $i.claimedBy, $i.title }
+}
+"#
+}
+
+fn init_toolbelt_db(workspace: &ExampleWorkspace) {
+    workspace.write_file("toolbelt.pg", toolbelt_schema());
+    workspace.write_file("toolbelt.gq", toolbelt_queries());
+
+    let init = workspace.json_value(&["--json", "init", "toolbelt.nano", "--schema", "toolbelt.pg"]);
+    assert_eq!(init["status"], "ok");
+}
+
+#[test]
+fn cli_put_is_idempotent_and_envelope_carries_matched_nodes() {
+    let workspace = ExampleWorkspace::copy(ExampleProject::Revops);
+    init_toolbelt_db(&workspace);
+
+    // First put — insert path. matched_nodes should be 1 (key gate).
+    let first = workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "ensure_issue",
+        "--param",
+        "slug=ng-001",
+        "--param",
+        "title=Refresh tokens",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(first.len(), 1);
+    assert_eq!(scalar_string(&first[0]["affected_nodes"]), "1");
+    assert_eq!(
+        scalar_string(&first[0]["matched_nodes"]),
+        "1",
+        "put envelope must carry matched_nodes (insert path)"
+    );
+
+    // Second put — update path. Idempotent; same envelope shape.
+    let second = workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "ensure_issue",
+        "--param",
+        "slug=ng-001",
+        "--param",
+        "title=Refresh tokens v2",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(second.len(), 1);
+    assert_eq!(scalar_string(&second[0]["affected_nodes"]), "1");
+    assert_eq!(
+        scalar_string(&second[0]["matched_nodes"]),
+        "1",
+        "put envelope must carry matched_nodes (update path)"
+    );
+
+    // Inspect confirms exactly one row, updated title.
+    let rows = workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "inspect",
+        "--param",
+        "slug=ng-001",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["slug"], "ng-001");
+    assert_eq!(rows[0]["title"], "Refresh tokens v2");
+    assert_eq!(rows[0]["status"], "open");
+}
+
+#[test]
+fn cli_cas_claim_envelope_distinguishes_winner_from_loser() {
+    let workspace = ExampleWorkspace::copy(ExampleProject::Revops);
+    init_toolbelt_db(&workspace);
+
+    // Seed an open issue.
+    workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "ensure_issue",
+        "--param",
+        "slug=ng-002",
+        "--param",
+        "title=The bug",
+        "--format",
+        "json",
+    ]);
+
+    // Alice claims — winner. matched=1, affected=1.
+    let alice = workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "claim_issue",
+        "--param",
+        "slug=ng-002",
+        "--param",
+        "agent=alice",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(alice.len(), 1);
+    assert_eq!(scalar_string(&alice[0]["matched_nodes"]), "1");
+    assert_eq!(scalar_string(&alice[0]["affected_nodes"]), "1");
+
+    // Bob claims — loser. matched=0, affected=0. No silent overwrite.
+    let bob = workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "claim_issue",
+        "--param",
+        "slug=ng-002",
+        "--param",
+        "agent=bob",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(bob.len(), 1);
+    assert_eq!(
+        scalar_string(&bob[0]["matched_nodes"]),
+        "0",
+        "CAS-lost signal: matched_nodes must be 0"
+    );
+    assert_eq!(scalar_string(&bob[0]["affected_nodes"]), "0");
+
+    // Inspect — Alice still owns the issue.
+    let inspect = workspace.json_rows(&[
+        "run",
+        "--db",
+        "toolbelt.nano",
+        "--query",
+        "toolbelt.gq",
+        "--name",
+        "inspect",
+        "--param",
+        "slug=ng-002",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(inspect.len(), 1);
+    assert_eq!(inspect[0]["claimedBy"], "alice");
+    assert_eq!(inspect[0]["status"], "in_progress");
+}

--- a/crates/nanograph/src/catalog/mod.rs
+++ b/crates/nanograph/src/catalog/mod.rs
@@ -26,6 +26,8 @@ pub struct NodeType {
     /// Maps @media_uri property -> mime property.
     pub media_uri_props: HashMap<String, String>,
     pub indexed_properties: HashSet<String>,
+    /// Name of the property marked with `@key`, if any.
+    pub key_property: Option<String>,
     pub arrow_schema: SchemaRef,
 }
 
@@ -78,8 +80,12 @@ pub fn build_catalog(schema: &SchemaFile) -> Result<Catalog> {
             let mut embed_sources = HashMap::new();
             let mut media_uri_props = HashMap::new();
             let mut indexed_properties = HashSet::new();
+            let mut key_property: Option<String> = None;
             for prop in &node.properties {
                 properties.insert(prop.name.clone(), prop.prop_type.clone());
+                if prop.annotations.iter().any(|ann| ann.name == "key") {
+                    key_property = Some(prop.name.clone());
+                }
                 if let Some(source_prop) = prop
                     .annotations
                     .iter()
@@ -127,6 +133,7 @@ pub fn build_catalog(schema: &SchemaFile) -> Result<Catalog> {
                     embed_sources,
                     media_uri_props,
                     indexed_properties,
+                    key_property,
                     arrow_schema,
                 },
             );

--- a/crates/nanograph/src/catalog/schema_ir.rs
+++ b/crates/nanograph/src/catalog/schema_ir.rs
@@ -290,6 +290,12 @@ pub fn build_catalog_from_ir(ir: &SchemaIR) -> Result<Catalog> {
                     fields.push(Field::new(&prop.name, prop_type.to_arrow(), prop.nullable));
                 }
 
+                let key_property = n
+                    .properties
+                    .iter()
+                    .find(|p| p.key)
+                    .map(|p| p.name.clone());
+
                 node_types.insert(
                     n.name.clone(),
                     NodeType {
@@ -298,6 +304,7 @@ pub fn build_catalog_from_ir(ir: &SchemaIR) -> Result<Catalog> {
                         embed_sources,
                         media_uri_props,
                         indexed_properties,
+                        key_property,
                         arrow_schema: Arc::new(Schema::new(fields)),
                     },
                 );

--- a/crates/nanograph/src/catalog/schema_ir.rs
+++ b/crates/nanograph/src/catalog/schema_ir.rs
@@ -290,11 +290,7 @@ pub fn build_catalog_from_ir(ir: &SchemaIR) -> Result<Catalog> {
                     fields.push(Field::new(&prop.name, prop_type.to_arrow(), prop.nullable));
                 }
 
-                let key_property = n
-                    .properties
-                    .iter()
-                    .find(|p| p.key)
-                    .map(|p| p.name.clone());
+                let key_property = n.properties.iter().find(|p| p.key).map(|p| p.name.clone());
 
                 node_types.insert(
                     n.name.clone(),

--- a/crates/nanograph/src/ir/lower.rs
+++ b/crates/nanograph/src/ir/lower.rs
@@ -456,38 +456,41 @@ fn lower_match_value(value: &MatchValue, param_names: &HashSet<String>) -> IRExp
     }
 }
 
-/// Lower a single-Compare-atom mutation predicate into the legacy IR shape.
-/// Multi-atom blocks and IS NULL atoms are rejected at typecheck time; this
-/// helper exists to bridge the new AST shape to the still-single-atom IR until
-/// the conjunctive executor lands.
+/// Lower an AST mutation predicate (Vec of atoms) into the IR shape.
+/// Each atom is lowered independently; the executor composes the masks via
+/// kleene-AND.
 fn lower_legacy_mutation_predicate(
     predicate: &crate::query::ast::MutationPredicate,
     param_names: &HashSet<String>,
 ) -> Result<IRMutationPredicate> {
     use crate::query::ast::MutationPredAtom;
-    if predicate.atoms.len() != 1 {
+    if predicate.atoms.is_empty() {
         return Err(crate::error::NanoError::Plan(
-            "lower: multi-atom mutation predicates not yet wired through the executor"
-                .to_string(),
+            "lower: mutation predicate has no atoms".to_string(),
         ));
     }
-    match &predicate.atoms[0] {
-        MutationPredAtom::Compare {
-            property,
-            op,
-            value,
-        } => Ok(IRMutationPredicate {
-            property: property.clone(),
-            op: *op,
-            value: lower_match_value(value, param_names),
-        }),
-        MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => Err(
-            crate::error::NanoError::Plan(
-                "lower: IS NULL / IS NOT NULL atoms not yet wired through the executor"
-                    .to_string(),
-            ),
-        ),
-    }
+    let atoms = predicate
+        .atoms
+        .iter()
+        .map(|atom| match atom {
+            MutationPredAtom::Compare {
+                property,
+                op,
+                value,
+            } => IRMutationPredAtom::Compare {
+                property: property.clone(),
+                op: *op,
+                value: lower_match_value(value, param_names),
+            },
+            MutationPredAtom::IsNull { property } => IRMutationPredAtom::IsNull {
+                property: property.clone(),
+            },
+            MutationPredAtom::IsNotNull { property } => IRMutationPredAtom::IsNotNull {
+                property: property.clone(),
+            },
+        })
+        .collect();
+    Ok(IRMutationPredicate { atoms })
 }
 
 #[cfg(test)]
@@ -579,7 +582,13 @@ query q($name: String, $age: I32) {
                 assert_eq!(type_name, "Person");
                 assert_eq!(assignments.len(), 1);
                 assert_eq!(assignments[0].property, "age");
-                assert_eq!(predicate.property, "name");
+                assert_eq!(predicate.atoms.len(), 1);
+                match &predicate.atoms[0] {
+                    IRMutationPredAtom::Compare { property, .. } => {
+                        assert_eq!(property, "name");
+                    }
+                    other => panic!("expected Compare atom, got {:?}", other),
+                }
             }
             _ => panic!("expected update mutation op"),
         }
@@ -673,10 +682,16 @@ query stamp() {
                     assignments[0].value,
                     IRExpr::Param(ref name) if name == NOW_PARAM_NAME
                 ));
-                assert!(matches!(
-                    predicate.value,
-                    IRExpr::Param(ref name) if name == NOW_PARAM_NAME
-                ));
+                assert_eq!(predicate.atoms.len(), 1);
+                match &predicate.atoms[0] {
+                    IRMutationPredAtom::Compare { value, .. } => {
+                        assert!(matches!(
+                            value,
+                            IRExpr::Param(name) if name == NOW_PARAM_NAME
+                        ));
+                    }
+                    other => panic!("expected Compare atom, got {:?}", other),
+                }
             }
             _ => panic!("expected update mutation op"),
         }

--- a/crates/nanograph/src/ir/lower.rs
+++ b/crates/nanograph/src/ir/lower.rs
@@ -90,19 +90,11 @@ pub fn lower_mutation_query(query: &QueryDecl) -> Result<MutationIR> {
                     value: lower_match_value(&a.value, &param_names),
                 })
                 .collect(),
-            predicate: IRMutationPredicate {
-                property: update.predicate.property.clone(),
-                op: update.predicate.op,
-                value: lower_match_value(&update.predicate.value, &param_names),
-            },
+            predicate: lower_legacy_mutation_predicate(&update.predicate, &param_names)?,
         },
         Mutation::Delete(delete) => MutationOpIR::Delete {
             type_name: delete.type_name.clone(),
-            predicate: IRMutationPredicate {
-                property: delete.predicate.property.clone(),
-                op: delete.predicate.op,
-                value: lower_match_value(&delete.predicate.value, &param_names),
-            },
+            predicate: lower_legacy_mutation_predicate(&delete.predicate, &param_names)?,
         },
     };
 
@@ -461,6 +453,40 @@ fn lower_match_value(value: &MatchValue, param_names: &HashSet<String>) -> IRExp
                 IRExpr::Variable(v.clone())
             }
         }
+    }
+}
+
+/// Lower a single-Compare-atom mutation predicate into the legacy IR shape.
+/// Multi-atom blocks and IS NULL atoms are rejected at typecheck time; this
+/// helper exists to bridge the new AST shape to the still-single-atom IR until
+/// the conjunctive executor lands.
+fn lower_legacy_mutation_predicate(
+    predicate: &crate::query::ast::MutationPredicate,
+    param_names: &HashSet<String>,
+) -> Result<IRMutationPredicate> {
+    use crate::query::ast::MutationPredAtom;
+    if predicate.atoms.len() != 1 {
+        return Err(crate::error::NanoError::Plan(
+            "lower: multi-atom mutation predicates not yet wired through the executor"
+                .to_string(),
+        ));
+    }
+    match &predicate.atoms[0] {
+        MutationPredAtom::Compare {
+            property,
+            op,
+            value,
+        } => Ok(IRMutationPredicate {
+            property: property.clone(),
+            op: *op,
+            value: lower_match_value(value, param_names),
+        }),
+        MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => Err(
+            crate::error::NanoError::Plan(
+                "lower: IS NULL / IS NOT NULL atoms not yet wired through the executor"
+                    .to_string(),
+            ),
+        ),
     }
 }
 

--- a/crates/nanograph/src/ir/lower.rs
+++ b/crates/nanograph/src/ir/lower.rs
@@ -80,6 +80,17 @@ pub fn lower_mutation_query(query: &QueryDecl) -> Result<MutationIR> {
                 })
                 .collect(),
         },
+        Mutation::Put(put) => MutationOpIR::Put {
+            type_name: put.type_name.clone(),
+            assignments: put
+                .assignments
+                .iter()
+                .map(|a| IRAssignment {
+                    property: a.property.clone(),
+                    value: lower_match_value(&a.value, &param_names),
+                })
+                .collect(),
+        },
         Mutation::Update(update) => MutationOpIR::Update {
             type_name: update.type_name.clone(),
             assignments: update

--- a/crates/nanograph/src/ir/mod.rs
+++ b/crates/nanograph/src/ir/mod.rs
@@ -47,9 +47,32 @@ pub struct IRAssignment {
 
 #[derive(Debug, Clone)]
 pub struct IRMutationPredicate {
-    pub property: String,
-    pub op: CompOp,
-    pub value: IRExpr,
+    pub atoms: Vec<IRMutationPredAtom>,
+}
+
+#[derive(Debug, Clone)]
+pub enum IRMutationPredAtom {
+    Compare {
+        property: String,
+        op: CompOp,
+        value: IRExpr,
+    },
+    IsNull {
+        property: String,
+    },
+    IsNotNull {
+        property: String,
+    },
+}
+
+impl IRMutationPredAtom {
+    pub fn property(&self) -> &str {
+        match self {
+            Self::Compare { property, .. }
+            | Self::IsNull { property }
+            | Self::IsNotNull { property } => property,
+        }
+    }
 }
 
 /// Resolved runtime parameters: param name → literal value.

--- a/crates/nanograph/src/ir/mod.rs
+++ b/crates/nanograph/src/ir/mod.rs
@@ -28,6 +28,10 @@ pub enum MutationOpIR {
         type_name: String,
         assignments: Vec<IRAssignment>,
     },
+    Put {
+        type_name: String,
+        assignments: Vec<IRAssignment>,
+    },
     Update {
         type_name: String,
         assignments: Vec<IRAssignment>,

--- a/crates/nanograph/src/plan/physical.rs
+++ b/crates/nanograph/src/plan/physical.rs
@@ -18,12 +18,17 @@ use datafusion_physical_plan::{
 };
 
 use crate::error::{NanoError, Result};
-use crate::ir::{IRAssignment, IRExpr, IRMutationPredicate, MutationIR, MutationOpIR, ParamMap};
+use crate::ir::{
+    IRAssignment, IRExpr, IRMutationPredAtom, IRMutationPredicate, MutationIR, MutationOpIR,
+    ParamMap,
+};
 use crate::plan::bindings::{binding_property_array, flat_binding_col, split_flat_binding_col};
 use crate::query::ast::{CompOp, Literal};
 use crate::store::csr::CsrIndex;
 use crate::store::database::persist::{read_sparse_node_batch, resolve_sparse_node_id_by_name};
-use crate::store::database::{Database, DatabaseWriteGuard, DeleteOp, DeletePredicate};
+use crate::store::database::{
+    Database, DatabaseWriteGuard, DeleteOp, DeletePredAtom, DeletePredicate,
+};
 use crate::store::metadata::DatabaseMetadata;
 use crate::store::runtime::{DatabaseRuntime, EdgeIndexPair, NodeLookup};
 use crate::types::Direction;
@@ -824,39 +829,38 @@ async fn execute_delete_edge_mutation(
     let src_type = edge_type.from_type.clone();
     let dst_type = edge_type.to_type.clone();
 
-    let delete_pred = build_delete_predicate(predicate, params)?;
-    let mapped_pred = match predicate.property.as_str() {
-        "from" => {
-            let endpoint = resolve_mutation_literal(&predicate.value, params)?;
-            let endpoint_name = literal_to_endpoint_name(&endpoint, "from")?;
-            let metadata = DatabaseMetadata::open(db.path())?;
-            let Some(src_id) =
-                resolve_sparse_node_id_by_name(&metadata, &src_type, &endpoint_name).await?
-            else {
-                return Ok(MutationExecResult::default());
-            };
-            DeletePredicate {
-                property: "src".to_string(),
-                op: delete_pred.op,
-                value: src_id.to_string(),
+    let mut mapped_atoms = Vec::with_capacity(predicate.atoms.len());
+    for atom in &predicate.atoms {
+        match atom {
+            IRMutationPredAtom::Compare {
+                property,
+                op,
+                value,
+            } if property == "from" || property == "to" => {
+                let endpoint = resolve_mutation_literal(value, params)?;
+                let endpoint_name = literal_to_endpoint_name(&endpoint, property)?;
+                let metadata = DatabaseMetadata::open(db.path())?;
+                let (target_type, internal_col) = if property == "from" {
+                    (&src_type, "src")
+                } else {
+                    (&dst_type, "dst")
+                };
+                let Some(node_id) =
+                    resolve_sparse_node_id_by_name(&metadata, target_type, &endpoint_name).await?
+                else {
+                    return Ok(MutationExecResult::default());
+                };
+                mapped_atoms.push(DeletePredAtom::Compare {
+                    property: internal_col.to_string(),
+                    op: comp_op_to_delete_op(*op)?,
+                    value: node_id.to_string(),
+                });
             }
+            other => mapped_atoms.push(ir_atom_to_delete_atom(other, params)?),
         }
-        "to" => {
-            let endpoint = resolve_mutation_literal(&predicate.value, params)?;
-            let endpoint_name = literal_to_endpoint_name(&endpoint, "to")?;
-            let metadata = DatabaseMetadata::open(db.path())?;
-            let Some(dst_id) =
-                resolve_sparse_node_id_by_name(&metadata, &dst_type, &endpoint_name).await?
-            else {
-                return Ok(MutationExecResult::default());
-            };
-            DeletePredicate {
-                property: "dst".to_string(),
-                op: delete_pred.op,
-                value: dst_id.to_string(),
-            }
-        }
-        _ => delete_pred,
+    }
+    let mapped_pred = DeletePredicate {
+        atoms: mapped_atoms,
     };
 
     let result = db
@@ -872,12 +876,38 @@ fn build_delete_predicate(
     predicate: &IRMutationPredicate,
     params: &ParamMap,
 ) -> Result<DeletePredicate> {
-    let lit = resolve_mutation_literal(&predicate.value, params)?;
-    Ok(DeletePredicate {
-        property: predicate.property.clone(),
-        op: comp_op_to_delete_op(predicate.op)?,
-        value: literal_to_predicate_string(&lit)?,
-    })
+    let atoms = predicate
+        .atoms
+        .iter()
+        .map(|a| ir_atom_to_delete_atom(a, params))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(DeletePredicate { atoms })
+}
+
+fn ir_atom_to_delete_atom(
+    atom: &IRMutationPredAtom,
+    params: &ParamMap,
+) -> Result<DeletePredAtom> {
+    match atom {
+        IRMutationPredAtom::Compare {
+            property,
+            op,
+            value,
+        } => {
+            let lit = resolve_mutation_literal(value, params)?;
+            Ok(DeletePredAtom::Compare {
+                property: property.clone(),
+                op: comp_op_to_delete_op(*op)?,
+                value: literal_to_predicate_string(&lit)?,
+            })
+        }
+        IRMutationPredAtom::IsNull { property } => Ok(DeletePredAtom::IsNull {
+            property: property.clone(),
+        }),
+        IRMutationPredAtom::IsNotNull { property } => Ok(DeletePredAtom::IsNotNull {
+            property: property.clone(),
+        }),
+    }
 }
 
 fn resolve_mutation_literal(expr: &IRExpr, params: &ParamMap) -> Result<Literal> {

--- a/crates/nanograph/src/plan/physical.rs
+++ b/crates/nanograph/src/plan/physical.rs
@@ -583,6 +583,8 @@ mod tests {
 pub struct MutationExecResult {
     pub affected_nodes: usize,
     pub affected_edges: usize,
+    /// See `crate::result::MutationResult::matched_nodes`.
+    pub matched_nodes: usize,
 }
 
 pub(crate) async fn execute_mutation(
@@ -649,6 +651,7 @@ async fn execute_put_mutation(
     Ok(MutationExecResult {
         affected_nodes: 1,
         affected_edges: 0,
+        matched_nodes: 1,
     })
 }
 
@@ -699,6 +702,7 @@ async fn execute_put_edge_mutation(
     Ok(MutationExecResult {
         affected_nodes: 0,
         affected_edges: 1,
+        matched_nodes: 1,
     })
 }
 
@@ -736,6 +740,7 @@ async fn execute_insert_mutation(
     Ok(MutationExecResult {
         affected_nodes: 1,
         affected_edges: 0,
+        matched_nodes: 0,
     })
 }
 
@@ -791,6 +796,7 @@ async fn execute_insert_edge_mutation(
     Ok(MutationExecResult {
         affected_nodes: 0,
         affected_edges: 1,
+        matched_nodes: 0,
     })
 }
 
@@ -877,6 +883,7 @@ async fn execute_update_mutation(
     Ok(MutationExecResult {
         affected_nodes: matched_rows.len(),
         affected_edges: 0,
+        matched_nodes: matched_rows.len(),
     })
 }
 
@@ -895,6 +902,7 @@ async fn execute_delete_mutation(
         return Ok(MutationExecResult {
             affected_nodes: result.deleted_nodes,
             affected_edges: result.deleted_edges,
+            matched_nodes: result.deleted_nodes,
         });
     }
 
@@ -963,6 +971,7 @@ async fn execute_delete_edge_mutation(
     Ok(MutationExecResult {
         affected_nodes: 0,
         affected_edges: result.deleted_edges,
+        matched_nodes: result.deleted_edges,
     })
 }
 

--- a/crates/nanograph/src/plan/physical.rs
+++ b/crates/nanograph/src/plan/physical.rs
@@ -987,10 +987,7 @@ fn build_delete_predicate(
     Ok(DeletePredicate { atoms })
 }
 
-fn ir_atom_to_delete_atom(
-    atom: &IRMutationPredAtom,
-    params: &ParamMap,
-) -> Result<DeletePredAtom> {
+fn ir_atom_to_delete_atom(atom: &IRMutationPredAtom, params: &ParamMap) -> Result<DeletePredAtom> {
     match atom {
         IRMutationPredAtom::Compare {
             property,

--- a/crates/nanograph/src/plan/physical.rs
+++ b/crates/nanograph/src/plan/physical.rs
@@ -596,6 +596,10 @@ pub(crate) async fn execute_mutation(
             type_name,
             assignments,
         } => execute_insert_mutation(db, type_name, assignments, params, writer).await,
+        MutationOpIR::Put {
+            type_name,
+            assignments,
+        } => execute_put_mutation(db, type_name, assignments, params, writer).await,
         MutationOpIR::Update {
             type_name,
             assignments,
@@ -606,6 +610,96 @@ pub(crate) async fn execute_mutation(
             predicate,
         } => execute_delete_mutation(db, type_name, predicate, params, writer).await,
     }
+}
+
+async fn execute_put_mutation(
+    db: &Database,
+    type_name: &str,
+    assignments: &[IRAssignment],
+    params: &ParamMap,
+    writer: &mut DatabaseWriteGuard<'_>,
+) -> Result<MutationExecResult> {
+    let is_node_type = db.catalog.node_types.contains_key(type_name);
+    let is_edge_type = db.catalog.edge_types.contains_key(type_name);
+    if is_edge_type {
+        return execute_put_edge_mutation(db, type_name, assignments, params, writer).await;
+    }
+    if !is_node_type {
+        return Err(NanoError::Execution(format!(
+            "unknown mutation target type `{}`",
+            type_name
+        )));
+    }
+
+    // Build a single-row JSONL line and apply through the merge path. Merge
+    // does key-based upsert: existing row → update non-key fields, missing row
+    // → insert. Idempotent for the same @key value.
+    let mut data = serde_json::Map::new();
+    for assignment in assignments {
+        let lit = resolve_mutation_literal(&assignment.value, params)?;
+        data.insert(assignment.property.clone(), literal_to_json(&lit)?);
+    }
+    let line = serde_json::json!({
+        "type": type_name,
+        "data": data,
+    })
+    .to_string();
+    db.apply_merge_mutation_locked(&line, "mutation:put_node", writer)
+        .await?;
+    Ok(MutationExecResult {
+        affected_nodes: 1,
+        affected_edges: 0,
+    })
+}
+
+async fn execute_put_edge_mutation(
+    db: &Database,
+    type_name: &str,
+    assignments: &[IRAssignment],
+    params: &ParamMap,
+    writer: &mut DatabaseWriteGuard<'_>,
+) -> Result<MutationExecResult> {
+    let mut from_name: Option<String> = None;
+    let mut to_name: Option<String> = None;
+    let mut data = serde_json::Map::new();
+
+    for assignment in assignments {
+        let lit = resolve_mutation_literal(&assignment.value, params)?;
+        match assignment.property.as_str() {
+            "from" => from_name = Some(literal_to_endpoint_name(&lit, "from")?),
+            "to" => to_name = Some(literal_to_endpoint_name(&lit, "to")?),
+            _ => {
+                data.insert(assignment.property.clone(), literal_to_json(&lit)?);
+            }
+        }
+    }
+
+    let from = from_name.ok_or_else(|| {
+        NanoError::Execution(format!(
+            "edge put for `{}` requires endpoint property `from`",
+            type_name
+        ))
+    })?;
+    let to = to_name.ok_or_else(|| {
+        NanoError::Execution(format!(
+            "edge put for `{}` requires endpoint property `to`",
+            type_name
+        ))
+    })?;
+
+    let line = serde_json::json!({
+        "edge": type_name,
+        "from": from,
+        "to": to,
+        "data": data,
+    })
+    .to_string();
+    db.apply_merge_mutation_locked(&line, "mutation:put_edge", writer)
+        .await?;
+    Ok(MutationExecResult {
+        affected_nodes: 0,
+        affected_edges: 1,
+    })
 }
 
 async fn execute_insert_mutation(

--- a/crates/nanograph/src/query/ast.rs
+++ b/crates/nanograph/src/query/ast.rs
@@ -215,7 +215,50 @@ pub struct MutationAssignment {
 
 #[derive(Debug, Clone)]
 pub struct MutationPredicate {
-    pub property: String,
-    pub op: CompOp,
-    pub value: MatchValue,
+    pub atoms: Vec<MutationPredAtom>,
+}
+
+#[derive(Debug, Clone)]
+pub enum MutationPredAtom {
+    Compare {
+        property: String,
+        op: CompOp,
+        value: MatchValue,
+    },
+    IsNull {
+        property: String,
+    },
+    IsNotNull {
+        property: String,
+    },
+}
+
+impl MutationPredAtom {
+    /// Name of the property this atom predicates on.
+    pub fn property(&self) -> &str {
+        match self {
+            Self::Compare { property, .. }
+            | Self::IsNull { property }
+            | Self::IsNotNull { property } => property,
+        }
+    }
+}
+
+impl MutationPredicate {
+    /// Returns the single Compare atom's fields if the predicate is exactly
+    /// one Compare atom, otherwise None. Used by the sparse-mutation fast paths
+    /// while the multi-atom executor is still being wired up.
+    pub fn legacy_single_compare(&self) -> Option<(&str, CompOp, &MatchValue)> {
+        if self.atoms.len() != 1 {
+            return None;
+        }
+        match &self.atoms[0] {
+            MutationPredAtom::Compare {
+                property,
+                op,
+                value,
+            } => Some((property.as_str(), *op, value)),
+            _ => None,
+        }
+    }
 }

--- a/crates/nanograph/src/query/ast.rs
+++ b/crates/nanograph/src/query/ast.rs
@@ -184,6 +184,7 @@ pub struct Ordering {
 #[derive(Debug, Clone)]
 pub enum Mutation {
     Insert(InsertMutation),
+    Put(InsertMutation),
     Update(UpdateMutation),
     Delete(DeleteMutation),
 }

--- a/crates/nanograph/src/query/parser.rs
+++ b/crates/nanograph/src/query/parser.rs
@@ -379,15 +379,63 @@ fn parse_mutation_assignment(pair: pest::iterators::Pair<Rule>) -> Result<Mutati
 }
 
 fn parse_mutation_predicate(pair: pest::iterators::Pair<Rule>) -> Result<MutationPredicate> {
-    let mut inner = pair.into_inner();
-    let property = inner.next().unwrap().as_str().to_string();
-    let op = parse_comp_op(inner.next().unwrap())?;
-    let value = parse_match_value(inner.next().unwrap())?;
-    Ok(MutationPredicate {
-        property,
-        op,
-        value,
-    })
+    let inner = pair.into_inner().next().ok_or_else(|| {
+        NanoError::Parse("mutation predicate is empty".to_string())
+    })?;
+    match inner.as_rule() {
+        Rule::mutation_pred_atom => {
+            let atom = parse_mutation_pred_atom(inner)?;
+            Ok(MutationPredicate { atoms: vec![atom] })
+        }
+        Rule::mutation_pred_block => {
+            let atoms = inner
+                .into_inner()
+                .filter(|p| matches!(p.as_rule(), Rule::mutation_pred_atom))
+                .map(parse_mutation_pred_atom)
+                .collect::<Result<Vec<_>>>()?;
+            if atoms.is_empty() {
+                return Err(NanoError::Parse(
+                    "mutation predicate block requires at least one atom".to_string(),
+                ));
+            }
+            Ok(MutationPredicate { atoms })
+        }
+        other => Err(NanoError::Parse(format!(
+            "unexpected mutation predicate rule: {:?}",
+            other
+        ))),
+    }
+}
+
+fn parse_mutation_pred_atom(pair: pest::iterators::Pair<Rule>) -> Result<MutationPredAtom> {
+    let inner = pair.into_inner().next().ok_or_else(|| {
+        NanoError::Parse("mutation predicate atom is empty".to_string())
+    })?;
+    match inner.as_rule() {
+        Rule::compare_pred => {
+            let mut parts = inner.into_inner();
+            let property = parts.next().unwrap().as_str().to_string();
+            let op = parse_comp_op(parts.next().unwrap())?;
+            let value = parse_match_value(parts.next().unwrap())?;
+            Ok(MutationPredAtom::Compare {
+                property,
+                op,
+                value,
+            })
+        }
+        Rule::is_null_pred => {
+            let property = inner.into_inner().next().unwrap().as_str().to_string();
+            Ok(MutationPredAtom::IsNull { property })
+        }
+        Rule::is_not_null_pred => {
+            let property = inner.into_inner().next().unwrap().as_str().to_string();
+            Ok(MutationPredAtom::IsNotNull { property })
+        }
+        other => Err(NanoError::Parse(format!(
+            "unexpected mutation predicate atom rule: {:?}",
+            other
+        ))),
+    }
 }
 
 fn parse_match_value(pair: pest::iterators::Pair<Rule>) -> Result<MatchValue> {
@@ -1205,8 +1253,14 @@ query set_age($name: String, $age: I32) {
             Mutation::Update(upd) => {
                 assert_eq!(upd.type_name, "Person");
                 assert_eq!(upd.assignments.len(), 1);
-                assert_eq!(upd.predicate.property, "name");
-                assert_eq!(upd.predicate.op, CompOp::Eq);
+                assert_eq!(upd.predicate.atoms.len(), 1);
+                match &upd.predicate.atoms[0] {
+                    MutationPredAtom::Compare { property, op, .. } => {
+                        assert_eq!(property, "name");
+                        assert_eq!(*op, CompOp::Eq);
+                    }
+                    other => panic!("expected Compare atom, got {:?}", other),
+                }
             }
             _ => panic!("expected Update mutation"),
         }
@@ -1224,8 +1278,14 @@ query drop_person($name: String) {
         match q.mutation.as_ref().expect("expected mutation") {
             Mutation::Delete(del) => {
                 assert_eq!(del.type_name, "Person");
-                assert_eq!(del.predicate.property, "name");
-                assert_eq!(del.predicate.op, CompOp::Eq);
+                assert_eq!(del.predicate.atoms.len(), 1);
+                match &del.predicate.atoms[0] {
+                    MutationPredAtom::Compare { property, op, .. } => {
+                        assert_eq!(property, "name");
+                        assert_eq!(*op, CompOp::Eq);
+                    }
+                    other => panic!("expected Compare atom, got {:?}", other),
+                }
             }
             _ => panic!("expected Delete mutation"),
         }
@@ -1291,7 +1351,13 @@ query stamp() {
         match mutation.queries[0].mutation.as_ref().unwrap() {
             Mutation::Update(update) => {
                 assert!(matches!(update.assignments[0].value, MatchValue::Now));
-                assert!(matches!(update.predicate.value, MatchValue::Now));
+                assert_eq!(update.predicate.atoms.len(), 1);
+                match &update.predicate.atoms[0] {
+                    MutationPredAtom::Compare { value, .. } => {
+                        assert!(matches!(value, MatchValue::Now));
+                    }
+                    other => panic!("expected Compare atom, got {:?}", other),
+                }
             }
             _ => panic!("expected update mutation"),
         }

--- a/crates/nanograph/src/query/parser.rs
+++ b/crates/nanograph/src/query/parser.rs
@@ -308,6 +308,7 @@ fn parse_prop_match(pair: pest::iterators::Pair<Rule>) -> Result<PropMatch> {
 fn parse_mutation_stmt(pair: pest::iterators::Pair<Rule>) -> Result<Mutation> {
     match pair.as_rule() {
         Rule::insert_stmt => parse_insert_mutation(pair).map(Mutation::Insert),
+        Rule::put_stmt => parse_insert_mutation(pair).map(Mutation::Put),
         Rule::update_stmt => parse_update_mutation(pair).map(Mutation::Update),
         Rule::delete_stmt => parse_delete_mutation(pair).map(Mutation::Delete),
         other => Err(NanoError::Parse(format!(

--- a/crates/nanograph/src/query/parser.rs
+++ b/crates/nanograph/src/query/parser.rs
@@ -380,9 +380,10 @@ fn parse_mutation_assignment(pair: pest::iterators::Pair<Rule>) -> Result<Mutati
 }
 
 fn parse_mutation_predicate(pair: pest::iterators::Pair<Rule>) -> Result<MutationPredicate> {
-    let inner = pair.into_inner().next().ok_or_else(|| {
-        NanoError::Parse("mutation predicate is empty".to_string())
-    })?;
+    let inner = pair
+        .into_inner()
+        .next()
+        .ok_or_else(|| NanoError::Parse("mutation predicate is empty".to_string()))?;
     match inner.as_rule() {
         Rule::mutation_pred_atom => {
             let atom = parse_mutation_pred_atom(inner)?;
@@ -409,9 +410,10 @@ fn parse_mutation_predicate(pair: pest::iterators::Pair<Rule>) -> Result<Mutatio
 }
 
 fn parse_mutation_pred_atom(pair: pest::iterators::Pair<Rule>) -> Result<MutationPredAtom> {
-    let inner = pair.into_inner().next().ok_or_else(|| {
-        NanoError::Parse("mutation predicate atom is empty".to_string())
-    })?;
+    let inner = pair
+        .into_inner()
+        .next()
+        .ok_or_else(|| NanoError::Parse("mutation predicate atom is empty".to_string()))?;
     match inner.as_rule() {
         Rule::compare_pred => {
             let mut parts = inner.into_inner();

--- a/crates/nanograph/src/query/query.pest
+++ b/crates/nanograph/src/query/query.pest
@@ -24,8 +24,9 @@ read_query_body = {
     ~ limit_clause?
 }
 
-mutation_stmt = { insert_stmt | update_stmt | delete_stmt }
+mutation_stmt = { insert_stmt | put_stmt | update_stmt | delete_stmt }
 insert_stmt = { "insert" ~ type_name ~ "{" ~ mutation_assignment+ ~ "}" }
+put_stmt = { "put" ~ type_name ~ "{" ~ mutation_assignment+ ~ "}" }
 update_stmt = { "update" ~ type_name ~ "set" ~ "{" ~ mutation_assignment+ ~ "}" ~ "where" ~ mutation_predicate }
 delete_stmt = { "delete" ~ type_name ~ "where" ~ mutation_predicate }
 mutation_assignment = { ident ~ ":" ~ match_value ~ ","? }

--- a/crates/nanograph/src/query/query.pest
+++ b/crates/nanograph/src/query/query.pest
@@ -29,7 +29,12 @@ insert_stmt = { "insert" ~ type_name ~ "{" ~ mutation_assignment+ ~ "}" }
 update_stmt = { "update" ~ type_name ~ "set" ~ "{" ~ mutation_assignment+ ~ "}" ~ "where" ~ mutation_predicate }
 delete_stmt = { "delete" ~ type_name ~ "where" ~ mutation_predicate }
 mutation_assignment = { ident ~ ":" ~ match_value ~ ","? }
-mutation_predicate = { ident ~ comp_op ~ match_value }
+mutation_predicate = { mutation_pred_block | mutation_pred_atom }
+mutation_pred_block = { "{" ~ mutation_pred_atom+ ~ "}" }
+mutation_pred_atom = { is_not_null_pred | is_null_pred | compare_pred }
+compare_pred = { ident ~ comp_op ~ match_value }
+is_null_pred = { ident ~ "is" ~ "null" }
+is_not_null_pred = { ident ~ "is" ~ "not" ~ "null" }
 
 param_list = { param ~ ("," ~ param)* }
 param = { variable ~ ":" ~ type_ref }

--- a/crates/nanograph/src/query/typecheck.rs
+++ b/crates/nanograph/src/query/typecheck.rs
@@ -406,27 +406,47 @@ fn ensure_no_duplicate_assignment_names(assignments: &[MutationAssignment]) -> R
     Ok(())
 }
 
+/// Extract the single legacy Compare atom from a mutation predicate.
+/// Multi-atom `where { ... }` blocks and IS NULL / IS NOT NULL atoms parse but
+/// are not yet implemented end-to-end (landing in a follow-up commit).
+fn require_single_compare_atom(
+    predicate: &MutationPredicate,
+) -> Result<(&str, CompOp, &MatchValue)> {
+    if predicate.atoms.len() != 1 {
+        return Err(NanoError::Type(
+            "T11: `where { ... }` blocks with multiple atoms are not yet supported"
+                .to_string(),
+        ));
+    }
+    match &predicate.atoms[0] {
+        MutationPredAtom::Compare {
+            property,
+            op,
+            value,
+        } => Ok((property.as_str(), *op, value)),
+        MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => Err(
+            NanoError::Type(
+                "T11: `IS NULL` / `IS NOT NULL` predicate atoms are not yet supported"
+                    .to_string(),
+            ),
+        ),
+    }
+}
+
 fn typecheck_mutation_predicate(
     type_name: &str,
     predicate: &MutationPredicate,
     node_type: &crate::catalog::NodeType,
     param_types: &HashMap<String, PropType>,
 ) -> Result<()> {
-    let prop_type = node_type
-        .properties
-        .get(&predicate.property)
-        .ok_or_else(|| {
-            NanoError::Type(format!(
-                "T11: type `{}` has no property `{}`",
-                type_name, predicate.property
-            ))
-        })?;
-    check_match_value_type(
-        &predicate.value,
-        param_types,
-        prop_type,
-        &predicate.property,
-    )?;
+    let (property, _op, value) = require_single_compare_atom(predicate)?;
+    let prop_type = node_type.properties.get(property).ok_or_else(|| {
+        NanoError::Type(format!(
+            "T11: type `{}` has no property `{}`",
+            type_name, property
+        ))
+    })?;
+    check_match_value_type(value, param_types, prop_type, property)?;
     Ok(())
 }
 
@@ -436,30 +456,23 @@ fn typecheck_edge_mutation_predicate(
     edge_type: &crate::catalog::EdgeType,
     param_types: &HashMap<String, PropType>,
 ) -> Result<()> {
-    if predicate.property == "from" || predicate.property == "to" {
+    let (property, _op, value) = require_single_compare_atom(predicate)?;
+    if property == "from" || property == "to" {
         return check_match_value_type(
-            &predicate.value,
+            value,
             param_types,
             &PropType::scalar(ScalarType::String, false),
-            &predicate.property,
+            property,
         );
     }
 
-    let prop_type = edge_type
-        .properties
-        .get(&predicate.property)
-        .ok_or_else(|| {
-            NanoError::Type(format!(
-                "T11: type `{}` has no property `{}`",
-                type_name, predicate.property
-            ))
-        })?;
-    check_match_value_type(
-        &predicate.value,
-        param_types,
-        prop_type,
-        &predicate.property,
-    )?;
+    let prop_type = edge_type.properties.get(property).ok_or_else(|| {
+        NanoError::Type(format!(
+            "T11: type `{}` has no property `{}`",
+            type_name, property
+        ))
+    })?;
+    check_match_value_type(value, param_types, prop_type, property)?;
     Ok(())
 }
 

--- a/crates/nanograph/src/query/typecheck.rs
+++ b/crates/nanograph/src/query/typecheck.rs
@@ -177,146 +177,178 @@ fn typecheck_read_query(catalog: &Catalog, query: &QueryDecl) -> Result<TypeCont
     Ok(ctx)
 }
 
-fn typecheck_mutation(catalog: &Catalog, mutation: &Mutation, params: &[Param]) -> Result<String> {
-    let param_types = parse_declared_param_types(params)?;
+/// Shared validation for `insert` and `put` (both have the same shape: a list of
+/// assignments). `kind` is interpolated into error messages ("insert" or "put").
+fn validate_insert_like(
+    catalog: &Catalog,
+    insert: &InsertMutation,
+    param_types: &HashMap<String, PropType>,
+    kind: &str,
+) -> Result<String> {
+    if insert.assignments.is_empty() {
+        return Err(NanoError::Type(format!(
+            "T10: {kind} mutation requires at least one assignment"
+        )));
+    }
 
-    match mutation {
-        Mutation::Insert(insert) => {
-            if insert.assignments.is_empty() {
-                return Err(NanoError::Type(
-                    "T10: insert mutation requires at least one assignment".to_string(),
-                ));
+    ensure_no_duplicate_assignment_names(&insert.assignments)?;
+
+    if let Some(node_type) = catalog.node_types.get(&insert.type_name) {
+        for assignment in &insert.assignments {
+            let prop_type =
+                node_type
+                    .properties
+                    .get(&assignment.property)
+                    .ok_or_else(|| {
+                        NanoError::Type(format!(
+                            "T11: type `{}` has no property `{}`",
+                            insert.type_name, assignment.property
+                        ))
+                    })?;
+            check_match_value_type(
+                &assignment.value,
+                param_types,
+                prop_type,
+                &assignment.property,
+            )?;
+        }
+
+        let assigned_props: HashSet<&str> = insert
+            .assignments
+            .iter()
+            .map(|assignment| assignment.property.as_str())
+            .collect();
+        for (prop_name, prop_type) in &node_type.properties {
+            if prop_type.nullable {
+                continue;
+            }
+            if assigned_props.contains(prop_name.as_str()) {
+                continue;
             }
 
-            ensure_no_duplicate_assignment_names(&insert.assignments)?;
+            if let Some(source_prop) = node_type.embed_sources.get(prop_name) {
+                if assigned_props.contains(source_prop.as_str()) {
+                    continue;
+                }
+                return Err(NanoError::Type(format!(
+                    "T12: {kind} for `{}` must provide non-nullable property `{}` or @embed source `{}`",
+                    insert.type_name, prop_name, source_prop
+                )));
+            }
 
-            if let Some(node_type) = catalog.node_types.get(&insert.type_name) {
-                for assignment in &insert.assignments {
-                    let prop_type =
-                        node_type
-                            .properties
-                            .get(&assignment.property)
-                            .ok_or_else(|| {
-                                NanoError::Type(format!(
-                                    "T11: type `{}` has no property `{}`",
-                                    insert.type_name, assignment.property
-                                ))
-                            })?;
+            return Err(NanoError::Type(format!(
+                "T12: {kind} for `{}` must provide non-nullable property `{}`",
+                insert.type_name, prop_name
+            )));
+        }
+        return Ok(insert.type_name.clone());
+    }
+
+    if let Some(edge_type) = catalog.edge_types.get(&insert.type_name) {
+        let mut has_from = false;
+        let mut has_to = false;
+
+        for assignment in &insert.assignments {
+            match assignment.property.as_str() {
+                "from" => {
+                    has_from = true;
                     check_match_value_type(
                         &assignment.value,
-                        &param_types,
+                        param_types,
+                        &PropType::scalar(ScalarType::String, false),
+                        "from",
+                    )?;
+                }
+                "to" => {
+                    has_to = true;
+                    check_match_value_type(
+                        &assignment.value,
+                        param_types,
+                        &PropType::scalar(ScalarType::String, false),
+                        "to",
+                    )?;
+                }
+                _ => {
+                    let prop_type = edge_type
+                        .properties
+                        .get(&assignment.property)
+                        .ok_or_else(|| {
+                            NanoError::Type(format!(
+                                "T11: type `{}` has no property `{}`",
+                                insert.type_name, assignment.property
+                            ))
+                        })?;
+                    check_match_value_type(
+                        &assignment.value,
+                        param_types,
                         prop_type,
                         &assignment.property,
                     )?;
                 }
-
-                let assigned_props: HashSet<&str> = insert
-                    .assignments
-                    .iter()
-                    .map(|assignment| assignment.property.as_str())
-                    .collect();
-                for (prop_name, prop_type) in &node_type.properties {
-                    if prop_type.nullable {
-                        continue;
-                    }
-                    if assigned_props.contains(prop_name.as_str()) {
-                        continue;
-                    }
-
-                    if let Some(source_prop) = node_type.embed_sources.get(prop_name) {
-                        if assigned_props.contains(source_prop.as_str()) {
-                            continue;
-                        }
-                        return Err(NanoError::Type(format!(
-                            "T12: insert for `{}` must provide non-nullable property `{}` or @embed source `{}`",
-                            insert.type_name, prop_name, source_prop
-                        )));
-                    }
-
-                    return Err(NanoError::Type(format!(
-                        "T12: insert for `{}` must provide non-nullable property `{}`",
-                        insert.type_name, prop_name
-                    )));
-                }
-                return Ok(insert.type_name.clone());
             }
-
-            if let Some(edge_type) = catalog.edge_types.get(&insert.type_name) {
-                let mut has_from = false;
-                let mut has_to = false;
-
-                for assignment in &insert.assignments {
-                    match assignment.property.as_str() {
-                        "from" => {
-                            has_from = true;
-                            check_match_value_type(
-                                &assignment.value,
-                                &param_types,
-                                &PropType::scalar(ScalarType::String, false),
-                                "from",
-                            )?;
-                        }
-                        "to" => {
-                            has_to = true;
-                            check_match_value_type(
-                                &assignment.value,
-                                &param_types,
-                                &PropType::scalar(ScalarType::String, false),
-                                "to",
-                            )?;
-                        }
-                        _ => {
-                            let prop_type = edge_type
-                                .properties
-                                .get(&assignment.property)
-                                .ok_or_else(|| {
-                                    NanoError::Type(format!(
-                                        "T11: type `{}` has no property `{}`",
-                                        insert.type_name, assignment.property
-                                    ))
-                                })?;
-                            check_match_value_type(
-                                &assignment.value,
-                                &param_types,
-                                prop_type,
-                                &assignment.property,
-                            )?;
-                        }
-                    }
-                }
-
-                if !has_from {
-                    return Err(NanoError::Type(format!(
-                        "T12: insert for `{}` must provide required endpoint `from`",
-                        insert.type_name
-                    )));
-                }
-                if !has_to {
-                    return Err(NanoError::Type(format!(
-                        "T12: insert for `{}` must provide required endpoint `to`",
-                        insert.type_name
-                    )));
-                }
-
-                for (prop_name, prop_type) in &edge_type.properties {
-                    if prop_type.nullable {
-                        continue;
-                    }
-                    if !insert.assignments.iter().any(|a| &a.property == prop_name) {
-                        return Err(NanoError::Type(format!(
-                            "T12: insert for `{}` must provide non-nullable property `{}`",
-                            insert.type_name, prop_name
-                        )));
-                    }
-                }
-                return Ok(insert.type_name.clone());
-            }
-
-            Err(NanoError::Type(format!(
-                "T10: unknown node/edge type `{}`",
-                insert.type_name
-            )))
         }
+
+        if !has_from {
+            return Err(NanoError::Type(format!(
+                "T12: {kind} for `{}` must provide required endpoint `from`",
+                insert.type_name
+            )));
+        }
+        if !has_to {
+            return Err(NanoError::Type(format!(
+                "T12: {kind} for `{}` must provide required endpoint `to`",
+                insert.type_name
+            )));
+        }
+
+        for (prop_name, prop_type) in &edge_type.properties {
+            if prop_type.nullable {
+                continue;
+            }
+            if !insert.assignments.iter().any(|a| &a.property == prop_name) {
+                return Err(NanoError::Type(format!(
+                    "T12: {kind} for `{}` must provide non-nullable property `{}`",
+                    insert.type_name, prop_name
+                )));
+            }
+        }
+        return Ok(insert.type_name.clone());
+    }
+
+    Err(NanoError::Type(format!(
+        "T10: unknown node/edge type `{}`",
+        insert.type_name
+    )))
+}
+
+fn typecheck_mutation(catalog: &Catalog, mutation: &Mutation, params: &[Param]) -> Result<String> {
+    let param_types = parse_declared_param_types(params)?;
+
+    match mutation {
+        Mutation::Put(put) => {
+            // Same shape as insert: validate the assignments against the type's
+            // schema. Then additionally require that the type has @key and that
+            // the @key property is present in the assignments (it's the gate
+            // that selects the row to update on conflict). For edges, (from, to)
+            // is the natural key — already enforced by the insert-like check.
+            validate_insert_like(catalog, put, &param_types, "put")?;
+            if let Some(node_type) = catalog.node_types.get(&put.type_name) {
+                let key = node_type.key_property.as_deref().ok_or_else(|| {
+                    NanoError::Type(format!(
+                        "T22: put requires node type `{}` to have @key",
+                        put.type_name
+                    ))
+                })?;
+                if !put.assignments.iter().any(|a| a.property == key) {
+                    return Err(NanoError::Type(format!(
+                        "T22: put for `{}` must include the @key property `{}`",
+                        put.type_name, key
+                    )));
+                }
+            }
+            return Ok(put.type_name.clone());
+        }
+        Mutation::Insert(insert) => validate_insert_like(catalog, insert, &param_types, "insert"),
         Mutation::Update(update) => {
             let node_type = if let Some(node_type) = catalog.node_types.get(&update.type_name) {
                 node_type

--- a/crates/nanograph/src/query/typecheck.rs
+++ b/crates/nanograph/src/query/typecheck.rs
@@ -195,16 +195,15 @@ fn validate_insert_like(
 
     if let Some(node_type) = catalog.node_types.get(&insert.type_name) {
         for assignment in &insert.assignments {
-            let prop_type =
-                node_type
-                    .properties
-                    .get(&assignment.property)
-                    .ok_or_else(|| {
-                        NanoError::Type(format!(
-                            "T11: type `{}` has no property `{}`",
-                            insert.type_name, assignment.property
-                        ))
-                    })?;
+            let prop_type = node_type
+                .properties
+                .get(&assignment.property)
+                .ok_or_else(|| {
+                    NanoError::Type(format!(
+                        "T11: type `{}` has no property `{}`",
+                        insert.type_name, assignment.property
+                    ))
+                })?;
             check_match_value_type(
                 &assignment.value,
                 param_types,
@@ -269,15 +268,16 @@ fn validate_insert_like(
                     )?;
                 }
                 _ => {
-                    let prop_type = edge_type
-                        .properties
-                        .get(&assignment.property)
-                        .ok_or_else(|| {
-                            NanoError::Type(format!(
-                                "T11: type `{}` has no property `{}`",
-                                insert.type_name, assignment.property
-                            ))
-                        })?;
+                    let prop_type =
+                        edge_type
+                            .properties
+                            .get(&assignment.property)
+                            .ok_or_else(|| {
+                                NanoError::Type(format!(
+                                    "T11: type `{}` has no property `{}`",
+                                    insert.type_name, assignment.property
+                                ))
+                            })?;
                     check_match_value_type(
                         &assignment.value,
                         param_types,

--- a/crates/nanograph/src/query/typecheck.rs
+++ b/crates/nanograph/src/query/typecheck.rs
@@ -406,47 +406,45 @@ fn ensure_no_duplicate_assignment_names(assignments: &[MutationAssignment]) -> R
     Ok(())
 }
 
-/// Extract the single legacy Compare atom from a mutation predicate.
-/// Multi-atom `where { ... }` blocks and IS NULL / IS NOT NULL atoms parse but
-/// are not yet implemented end-to-end (landing in a follow-up commit).
-fn require_single_compare_atom(
-    predicate: &MutationPredicate,
-) -> Result<(&str, CompOp, &MatchValue)> {
-    if predicate.atoms.len() != 1 {
-        return Err(NanoError::Type(
-            "T11: `where { ... }` blocks with multiple atoms are not yet supported"
-                .to_string(),
-        ));
-    }
-    match &predicate.atoms[0] {
-        MutationPredAtom::Compare {
-            property,
-            op,
-            value,
-        } => Ok((property.as_str(), *op, value)),
-        MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => Err(
-            NanoError::Type(
-                "T11: `IS NULL` / `IS NOT NULL` predicate atoms are not yet supported"
-                    .to_string(),
-            ),
-        ),
-    }
-}
-
 fn typecheck_mutation_predicate(
     type_name: &str,
     predicate: &MutationPredicate,
     node_type: &crate::catalog::NodeType,
     param_types: &HashMap<String, PropType>,
 ) -> Result<()> {
-    let (property, _op, value) = require_single_compare_atom(predicate)?;
-    let prop_type = node_type.properties.get(property).ok_or_else(|| {
-        NanoError::Type(format!(
-            "T11: type `{}` has no property `{}`",
-            type_name, property
-        ))
-    })?;
-    check_match_value_type(value, param_types, prop_type, property)?;
+    if predicate.atoms.is_empty() {
+        return Err(NanoError::Type(
+            "T11: mutation predicate must contain at least one atom".to_string(),
+        ));
+    }
+    for atom in &predicate.atoms {
+        let property = atom.property();
+        let prop_type = node_type.properties.get(property).ok_or_else(|| {
+            NanoError::Type(format!(
+                "T11: type `{}` has no property `{}`",
+                type_name, property
+            ))
+        })?;
+        match atom {
+            MutationPredAtom::Compare { op: _, value, .. } => {
+                check_match_value_type(value, param_types, prop_type, property)?;
+            }
+            MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => {
+                if !prop_type.nullable {
+                    return Err(NanoError::Type(format!(
+                        "T11: `{}.{}` is non-nullable; IS NULL / IS NOT NULL is always {}",
+                        type_name,
+                        property,
+                        if matches!(atom, MutationPredAtom::IsNull { .. }) {
+                            "false"
+                        } else {
+                            "true"
+                        }
+                    )));
+                }
+            }
+        }
+    }
     Ok(())
 }
 
@@ -456,23 +454,62 @@ fn typecheck_edge_mutation_predicate(
     edge_type: &crate::catalog::EdgeType,
     param_types: &HashMap<String, PropType>,
 ) -> Result<()> {
-    let (property, _op, value) = require_single_compare_atom(predicate)?;
-    if property == "from" || property == "to" {
-        return check_match_value_type(
-            value,
-            param_types,
-            &PropType::scalar(ScalarType::String, false),
-            property,
-        );
+    if predicate.atoms.is_empty() {
+        return Err(NanoError::Type(
+            "T11: mutation predicate must contain at least one atom".to_string(),
+        ));
     }
+    for atom in &predicate.atoms {
+        let property = atom.property();
+        // Edges have implicit non-nullable `from`/`to` endpoints plus declared
+        // properties. Compare on from/to is endpoint resolution; IS NULL on
+        // from/to is always false (rejected).
+        if property == "from" || property == "to" {
+            match atom {
+                MutationPredAtom::Compare { value, .. } => {
+                    check_match_value_type(
+                        value,
+                        param_types,
+                        &PropType::scalar(ScalarType::String, false),
+                        property,
+                    )?;
+                    continue;
+                }
+                MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => {
+                    return Err(NanoError::Type(format!(
+                        "T11: edge endpoint `{}` is always non-null; IS NULL / IS NOT NULL not applicable",
+                        property
+                    )));
+                }
+            }
+        }
 
-    let prop_type = edge_type.properties.get(property).ok_or_else(|| {
-        NanoError::Type(format!(
-            "T11: type `{}` has no property `{}`",
-            type_name, property
-        ))
-    })?;
-    check_match_value_type(value, param_types, prop_type, property)?;
+        let prop_type = edge_type.properties.get(property).ok_or_else(|| {
+            NanoError::Type(format!(
+                "T11: type `{}` has no property `{}`",
+                type_name, property
+            ))
+        })?;
+        match atom {
+            MutationPredAtom::Compare { value, .. } => {
+                check_match_value_type(value, param_types, prop_type, property)?;
+            }
+            MutationPredAtom::IsNull { .. } | MutationPredAtom::IsNotNull { .. } => {
+                if !prop_type.nullable {
+                    return Err(NanoError::Type(format!(
+                        "T11: `{}.{}` is non-nullable; IS NULL / IS NOT NULL is always {}",
+                        type_name,
+                        property,
+                        if matches!(atom, MutationPredAtom::IsNull { .. }) {
+                            "false"
+                        } else {
+                            "true"
+                        }
+                    )));
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/nanograph/src/result.rs
+++ b/crates/nanograph/src/result.rs
@@ -75,6 +75,13 @@ impl QueryResult {
 pub struct MutationResult {
     pub affected_nodes: usize,
     pub affected_edges: usize,
+    /// Count of rows the predicate matched before applying the write.
+    /// For update/delete: number of rows the `where { ... }` block matched.
+    /// For put: 1 (the key gate always identifies exactly one row).
+    /// For insert: 0 (no gate; insert is a pure append).
+    /// `matched_nodes == 0 && affected_nodes == 0` means a CAS predicate
+    /// matched no rows — the canonical "claim lost" signal for agents.
+    pub matched_nodes: usize,
 }
 
 impl MutationResult {
@@ -82,6 +89,7 @@ impl MutationResult {
         serde_json::json!({
             "affectedNodes": self.affected_nodes,
             "affectedEdges": self.affected_edges,
+            "matchedNodes": self.matched_nodes,
         })
     }
 
@@ -89,12 +97,14 @@ impl MutationResult {
         let schema = Arc::new(Schema::new(vec![
             Field::new("affected_nodes", DataType::UInt64, false),
             Field::new("affected_edges", DataType::UInt64, false),
+            Field::new("matched_nodes", DataType::UInt64, false),
         ]));
         Ok(RecordBatch::try_new(
             schema,
             vec![
                 Arc::new(UInt64Array::from(vec![self.affected_nodes as u64])),
                 Arc::new(UInt64Array::from(vec![self.affected_edges as u64])),
+                Arc::new(UInt64Array::from(vec![self.matched_nodes as u64])),
             ],
         )?)
     }
@@ -105,6 +115,7 @@ impl From<MutationExecResult> for MutationResult {
         Self {
             affected_nodes: value.affected_nodes,
             affected_edges: value.affected_edges,
+            matched_nodes: value.matched_nodes,
         }
     }
 }

--- a/crates/nanograph/src/store/database.rs
+++ b/crates/nanograph/src/store/database.rs
@@ -69,9 +69,45 @@ pub enum LoadMode {
 
 #[derive(Debug, Clone)]
 pub struct DeletePredicate {
-    pub property: String,
-    pub op: DeleteOp,
-    pub value: String,
+    pub atoms: Vec<DeletePredAtom>,
+}
+
+#[derive(Debug, Clone)]
+pub enum DeletePredAtom {
+    Compare {
+        property: String,
+        op: DeleteOp,
+        value: String,
+    },
+    IsNull {
+        property: String,
+    },
+    IsNotNull {
+        property: String,
+    },
+}
+
+impl DeletePredicate {
+    /// Single-Compare predicate (the common case).
+    pub fn compare(property: String, op: DeleteOp, value: String) -> Self {
+        Self {
+            atoms: vec![DeletePredAtom::Compare {
+                property,
+                op,
+                value,
+            }],
+        }
+    }
+}
+
+impl DeletePredAtom {
+    pub fn property(&self) -> &str {
+        match self {
+            Self::Compare { property, .. }
+            | Self::IsNull { property }
+            | Self::IsNotNull { property } => property,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/nanograph/src/store/database/cdc.rs
+++ b/crates/nanograph/src/store/database/cdc.rs
@@ -15,7 +15,10 @@ use super::persist::{
     collect_ids_from_batch, filter_record_batch_by_delete_mask, read_sparse_edge_batch,
     read_sparse_node_batch, select_record_batch_rows,
 };
-use super::{Database, DatabaseWriteGuard, DeleteOp, DeletePredicate, DeleteResult, MutationPlan};
+use super::{
+    Database, DatabaseWriteGuard, DeleteOp, DeletePredAtom, DeletePredicate, DeleteResult,
+    MutationPlan,
+};
 use crate::error::{NanoError, Result};
 use crate::store::metadata::DatabaseMetadata;
 use crate::store::txlog::{CdcLogEntry, VisibleChangeRow, read_visible_change_rows};
@@ -35,7 +38,7 @@ impl Database {
     }
 
     /// Delete nodes of a given type matching a predicate, cascading incident edges.
-    #[instrument(skip(self), fields(type_name = type_name, property = %predicate.property))]
+    #[instrument(skip(self), fields(type_name = type_name, atoms = predicate.atoms.len()))]
     pub async fn delete_nodes(
         &self,
         type_name: &str,
@@ -145,7 +148,7 @@ impl Database {
     }
 
     /// Delete edges of a given type matching a predicate.
-    #[instrument(skip(self), fields(type_name = type_name, property = %predicate.property))]
+    #[instrument(skip(self), fields(type_name = type_name, atoms = predicate.atoms.len()))]
     pub async fn delete_edges(
         &self,
         type_name: &str,
@@ -350,17 +353,90 @@ pub(super) fn build_delete_mask_for_mutation(
     batch: &RecordBatch,
     predicate: &DeletePredicate,
 ) -> Result<BooleanArray> {
-    let left = batch
-        .column_by_name(&predicate.property)
-        .ok_or_else(|| {
-            NanoError::Storage(format!(
-                "property '{}' not found for delete predicate",
-                predicate.property
-            ))
-        })?
-        .clone();
-    let right = parse_predicate_array(&predicate.value, left.data_type(), batch.num_rows())?;
-    compare_for_delete(&left, &right, predicate.op)
+    if predicate.atoms.is_empty() {
+        return Err(NanoError::Storage(
+            "delete predicate must contain at least one atom".to_string(),
+        ));
+    }
+    let mut combined: Option<BooleanArray> = None;
+    for atom in &predicate.atoms {
+        let atom_mask = build_mask_for_atom(batch, atom)?;
+        combined = Some(match combined {
+            None => atom_mask,
+            Some(prev) => kleene_and(&prev, &atom_mask)?,
+        });
+    }
+    combined.ok_or_else(|| NanoError::Storage("empty delete predicate".to_string()))
+}
+
+fn build_mask_for_atom(batch: &RecordBatch, atom: &DeletePredAtom) -> Result<BooleanArray> {
+    match atom {
+        DeletePredAtom::Compare {
+            property,
+            op,
+            value,
+        } => {
+            let left = batch.column_by_name(property).ok_or_else(|| {
+                NanoError::Storage(format!(
+                    "property '{}' not found for delete predicate",
+                    property
+                ))
+            })?;
+            let right = parse_predicate_array(value, left.data_type(), batch.num_rows())?;
+            compare_for_delete(left, &right, *op)
+        }
+        DeletePredAtom::IsNull { property } => {
+            let col = batch.column_by_name(property).ok_or_else(|| {
+                NanoError::Storage(format!(
+                    "property '{}' not found for delete predicate",
+                    property
+                ))
+            })?;
+            let mut builder = BooleanBuilder::with_capacity(col.len());
+            for row in 0..col.len() {
+                builder.append_value(col.is_null(row));
+            }
+            Ok(builder.finish())
+        }
+        DeletePredAtom::IsNotNull { property } => {
+            let col = batch.column_by_name(property).ok_or_else(|| {
+                NanoError::Storage(format!(
+                    "property '{}' not found for delete predicate",
+                    property
+                ))
+            })?;
+            let mut builder = BooleanBuilder::with_capacity(col.len());
+            for row in 0..col.len() {
+                builder.append_value(!col.is_null(row));
+            }
+            Ok(builder.finish())
+        }
+    }
+}
+
+/// Three-valued (kleene) AND of two boolean masks. Mirrors SQL semantics:
+/// false AND null = false; true AND null = null; null AND null = null.
+fn kleene_and(a: &BooleanArray, b: &BooleanArray) -> Result<BooleanArray> {
+    if a.len() != b.len() {
+        return Err(NanoError::Storage(format!(
+            "mask length mismatch in kleene AND: {} vs {}",
+            a.len(),
+            b.len()
+        )));
+    }
+    let mut builder = BooleanBuilder::with_capacity(a.len());
+    for row in 0..a.len() {
+        let a_null = a.is_null(row);
+        let b_null = b.is_null(row);
+        let a_val = if a_null { None } else { Some(a.value(row)) };
+        let b_val = if b_null { None } else { Some(b.value(row)) };
+        match (a_val, b_val) {
+            (Some(false), _) | (_, Some(false)) => builder.append_value(false),
+            (Some(true), Some(true)) => builder.append_value(true),
+            _ => builder.append_null(),
+        }
+    }
+    Ok(builder.finish())
 }
 
 fn filter_edge_batch_by_deleted_nodes(

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -640,6 +640,14 @@ pub async fn run_mutation_query_sparse(
         .as_ref()
         .ok_or_else(|| NanoError::Execution("expected mutation query".to_string()))?;
     match mutation {
+        Mutation::Put(put) => {
+            // Put is routed through the GraphAware path by the CLI classifier;
+            // this arm is unreachable in practice but kept for exhaustiveness.
+            Err(NanoError::Execution(format!(
+                "internal: put for `{}` should be routed to the GraphAware path",
+                put.type_name
+            )))
+        }
         Mutation::Insert(insert) => {
             let metadata = DatabaseMetadata::open(db_path)?;
             if metadata

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -835,11 +835,18 @@ pub async fn run_mutation_query_sparse(
             else {
                 return Ok(MutationResult::default());
             };
+            let (pred_property, pred_op, pred_value) = update
+                .predicate
+                .legacy_single_compare()
+                .ok_or_else(|| NanoError::Plan(
+                    "sparse mutation: multi-atom `where` blocks are not yet supported"
+                        .to_string(),
+                ))?;
             let delete_pred = DeletePredicate {
-                property: update.predicate.property.clone(),
-                op: comp_op_to_delete_op(update.predicate.op)?,
+                property: pred_property.to_string(),
+                op: comp_op_to_delete_op(pred_op)?,
                 value: literal_to_predicate_string(&resolve_mutation_match_value(
-                    &update.predicate.value,
+                    pred_value,
                     &runtime_params,
                 )?)?,
             };
@@ -953,11 +960,18 @@ pub async fn run_mutation_query_sparse(
                 else {
                     return Ok(MutationResult::default());
                 };
+                let (pred_property, pred_op, pred_value) = delete
+                    .predicate
+                    .legacy_single_compare()
+                    .ok_or_else(|| NanoError::Plan(
+                        "sparse mutation: multi-atom `where` blocks are not yet supported"
+                            .to_string(),
+                    ))?;
                 let delete_pred = DeletePredicate {
-                    property: delete.predicate.property.clone(),
-                    op: comp_op_to_delete_op(delete.predicate.op)?,
+                    property: pred_property.to_string(),
+                    op: comp_op_to_delete_op(pred_op)?,
                     value: literal_to_predicate_string(&resolve_mutation_match_value(
-                        &delete.predicate.value,
+                        pred_value,
                         &runtime_params,
                     )?)?,
                 };
@@ -1014,12 +1028,19 @@ pub async fn run_mutation_query_sparse(
                 else {
                     return Ok(MutationResult::default());
                 };
+                let (edge_pred_property, edge_pred_op, edge_pred_value) = delete
+                    .predicate
+                    .legacy_single_compare()
+                    .ok_or_else(|| NanoError::Plan(
+                        "sparse edge mutation: multi-atom `where` blocks are not yet supported"
+                            .to_string(),
+                    ))?;
                 let Some(delete_pred) = map_sparse_edge_delete_predicate(
                     &metadata,
                     &delete.type_name,
-                    &delete.predicate.property,
-                    delete.predicate.op,
-                    &delete.predicate.value,
+                    edge_pred_property,
+                    edge_pred_op,
+                    edge_pred_value,
                     &runtime_params,
                 )
                 .await?

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -705,6 +705,7 @@ pub async fn run_mutation_query_sparse(
                 return Ok(MutationResult {
                     affected_nodes,
                     affected_edges: 0,
+                    matched_nodes: 0,
                 });
             }
             if metadata
@@ -789,6 +790,7 @@ pub async fn run_mutation_query_sparse(
                 return Ok(MutationResult {
                     affected_nodes: 0,
                     affected_edges,
+                    matched_nodes: 0,
                 });
             }
             Err(NanoError::Execution(format!(
@@ -937,6 +939,7 @@ pub async fn run_mutation_query_sparse(
             Ok(MutationResult {
                 affected_nodes,
                 affected_edges: 0,
+                matched_nodes: affected_nodes,
             })
         }
         Mutation::Delete(delete) => {
@@ -1000,6 +1003,7 @@ pub async fn run_mutation_query_sparse(
                 return Ok(MutationResult {
                     affected_nodes: delete_ids.len(),
                     affected_edges: 0,
+                    matched_nodes: delete_ids.len(),
                 });
             }
             if metadata
@@ -1063,6 +1067,7 @@ pub async fn run_mutation_query_sparse(
                 return Ok(MutationResult {
                     affected_nodes: 0,
                     affected_edges: delete_ids.len(),
+                    matched_nodes: delete_ids.len(),
                 });
             }
             Err(NanoError::Execution(format!(

--- a/crates/nanograph/src/store/database/persist.rs
+++ b/crates/nanograph/src/store/database/persist.rs
@@ -10,13 +10,15 @@ use tracing::{debug, info, warn};
 
 use super::mutation::{DatasetMutationPlan, EdgeDelta, MutationDelta, NodeDelta};
 use super::{
-    Database, DatabaseWriteGuard, DeletePredicate, EmbedOptions, EmbedResult, LoadMode,
-    MutationPlan, MutationSource,
+    Database, DatabaseWriteGuard, DeletePredAtom, DeletePredicate, EmbedOptions, EmbedResult,
+    LoadMode, MutationPlan, MutationSource,
 };
 use crate::catalog::schema_ir::SchemaIR;
 use crate::error::{NanoError, Result};
 use crate::json_output::array_value_to_json;
-use crate::query::ast::{CompOp, Literal, MatchValue, Mutation, QueryDecl};
+use crate::query::ast::{
+    CompOp, Literal, MatchValue, Mutation, MutationPredAtom, MutationPredicate, QueryDecl,
+};
 use crate::result::MutationResult;
 use crate::store::graph::DatasetAccumulator;
 use crate::store::graph_mirror::rebuild_graph_mirror_from_wal;
@@ -835,21 +837,8 @@ pub async fn run_mutation_query_sparse(
             else {
                 return Ok(MutationResult::default());
             };
-            let (pred_property, pred_op, pred_value) = update
-                .predicate
-                .legacy_single_compare()
-                .ok_or_else(|| NanoError::Plan(
-                    "sparse mutation: multi-atom `where` blocks are not yet supported"
-                        .to_string(),
-                ))?;
-            let delete_pred = DeletePredicate {
-                property: pred_property.to_string(),
-                op: comp_op_to_delete_op(pred_op)?,
-                value: literal_to_predicate_string(&resolve_mutation_match_value(
-                    pred_value,
-                    &runtime_params,
-                )?)?,
-            };
+            let delete_pred =
+                ast_predicate_to_delete_predicate(&update.predicate, &runtime_params)?;
             let match_mask = crate::store::database::build_delete_mask_for_mutation(
                 &target_batch,
                 &delete_pred,
@@ -960,21 +949,8 @@ pub async fn run_mutation_query_sparse(
                 else {
                     return Ok(MutationResult::default());
                 };
-                let (pred_property, pred_op, pred_value) = delete
-                    .predicate
-                    .legacy_single_compare()
-                    .ok_or_else(|| NanoError::Plan(
-                        "sparse mutation: multi-atom `where` blocks are not yet supported"
-                            .to_string(),
-                    ))?;
-                let delete_pred = DeletePredicate {
-                    property: pred_property.to_string(),
-                    op: comp_op_to_delete_op(pred_op)?,
-                    value: literal_to_predicate_string(&resolve_mutation_match_value(
-                        pred_value,
-                        &runtime_params,
-                    )?)?,
-                };
+                let delete_pred =
+                    ast_predicate_to_delete_predicate(&delete.predicate, &runtime_params)?;
                 let delete_mask = crate::store::database::build_delete_mask_for_mutation(
                     &target_batch,
                     &delete_pred,
@@ -1028,19 +1004,10 @@ pub async fn run_mutation_query_sparse(
                 else {
                     return Ok(MutationResult::default());
                 };
-                let (edge_pred_property, edge_pred_op, edge_pred_value) = delete
-                    .predicate
-                    .legacy_single_compare()
-                    .ok_or_else(|| NanoError::Plan(
-                        "sparse edge mutation: multi-atom `where` blocks are not yet supported"
-                            .to_string(),
-                    ))?;
                 let Some(delete_pred) = map_sparse_edge_delete_predicate(
                     &metadata,
                     &delete.type_name,
-                    edge_pred_property,
-                    edge_pred_op,
-                    edge_pred_value,
+                    &delete.predicate,
                     &runtime_params,
                 )
                 .await?
@@ -1826,66 +1793,85 @@ pub(crate) fn filter_record_batch_by_delete_mask(
         .map_err(|e| NanoError::Storage(format!("{} delete filter error: {}", entity_kind, e)))
 }
 
+fn ast_atom_to_delete_atom(
+    atom: &MutationPredAtom,
+    params: &crate::ParamMap,
+) -> Result<DeletePredAtom> {
+    match atom {
+        MutationPredAtom::Compare {
+            property,
+            op,
+            value,
+        } => Ok(DeletePredAtom::Compare {
+            property: property.clone(),
+            op: comp_op_to_delete_op(*op)?,
+            value: literal_to_predicate_string(&resolve_mutation_match_value(value, params)?)?,
+        }),
+        MutationPredAtom::IsNull { property } => Ok(DeletePredAtom::IsNull {
+            property: property.clone(),
+        }),
+        MutationPredAtom::IsNotNull { property } => Ok(DeletePredAtom::IsNotNull {
+            property: property.clone(),
+        }),
+    }
+}
+
+fn ast_predicate_to_delete_predicate(
+    predicate: &MutationPredicate,
+    params: &crate::ParamMap,
+) -> Result<DeletePredicate> {
+    let atoms = predicate
+        .atoms
+        .iter()
+        .map(|a| ast_atom_to_delete_atom(a, params))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(DeletePredicate { atoms })
+}
+
 async fn map_sparse_edge_delete_predicate(
     metadata: &DatabaseMetadata,
     edge_type_name: &str,
-    property: &str,
-    op: CompOp,
-    value: &MatchValue,
+    predicate: &MutationPredicate,
     params: &crate::ParamMap,
 ) -> Result<Option<DeletePredicate>> {
-    let delete_op = comp_op_to_delete_op(op)?;
-    match property {
-        "from" => {
-            let edge_type = metadata
-                .catalog()
-                .edge_types
-                .get(edge_type_name)
-                .ok_or_else(|| {
-                    NanoError::Execution(format!("unknown edge type `{}`", edge_type_name))
-                })?;
-            let endpoint = resolve_mutation_match_value(value, params)?;
-            let endpoint_name = literal_to_endpoint_name(&endpoint, "from")?;
-            let Some(src_id) =
-                resolve_sparse_node_id_by_name(metadata, &edge_type.from_type, &endpoint_name)
-                    .await?
-            else {
-                return Ok(None);
-            };
-            Ok(Some(DeletePredicate {
-                property: "src".to_string(),
-                op: delete_op,
-                value: src_id.to_string(),
-            }))
+    let edge_type = metadata
+        .catalog()
+        .edge_types
+        .get(edge_type_name)
+        .ok_or_else(|| NanoError::Execution(format!("unknown edge type `{}`", edge_type_name)))?;
+    let from_type = edge_type.from_type.clone();
+    let to_type = edge_type.to_type.clone();
+
+    let mut atoms = Vec::with_capacity(predicate.atoms.len());
+    for atom in &predicate.atoms {
+        match atom {
+            MutationPredAtom::Compare {
+                property,
+                op,
+                value,
+            } if property == "from" || property == "to" => {
+                let endpoint = resolve_mutation_match_value(value, params)?;
+                let endpoint_name = literal_to_endpoint_name(&endpoint, property)?;
+                let (target_type, internal_col) = if property == "from" {
+                    (&from_type, "src")
+                } else {
+                    (&to_type, "dst")
+                };
+                let Some(node_id) =
+                    resolve_sparse_node_id_by_name(metadata, target_type, &endpoint_name).await?
+                else {
+                    return Ok(None);
+                };
+                atoms.push(DeletePredAtom::Compare {
+                    property: internal_col.to_string(),
+                    op: comp_op_to_delete_op(*op)?,
+                    value: node_id.to_string(),
+                });
+            }
+            other => atoms.push(ast_atom_to_delete_atom(other, params)?),
         }
-        "to" => {
-            let edge_type = metadata
-                .catalog()
-                .edge_types
-                .get(edge_type_name)
-                .ok_or_else(|| {
-                    NanoError::Execution(format!("unknown edge type `{}`", edge_type_name))
-                })?;
-            let endpoint = resolve_mutation_match_value(value, params)?;
-            let endpoint_name = literal_to_endpoint_name(&endpoint, "to")?;
-            let Some(dst_id) =
-                resolve_sparse_node_id_by_name(metadata, &edge_type.to_type, &endpoint_name)
-                    .await?
-            else {
-                return Ok(None);
-            };
-            Ok(Some(DeletePredicate {
-                property: "dst".to_string(),
-                op: delete_op,
-                value: dst_id.to_string(),
-            }))
-        }
-        _ => Ok(Some(DeletePredicate {
-            property: property.to_string(),
-            op: delete_op,
-            value: literal_to_predicate_string(&resolve_mutation_match_value(value, params)?)?,
-        })),
     }
+    Ok(Some(DeletePredicate { atoms }))
 }
 
 pub(crate) async fn resolve_sparse_node_id_by_name(

--- a/crates/nanograph/src/store/database/tests.rs
+++ b/crates/nanograph/src/store/database/tests.rs
@@ -1360,11 +1360,7 @@ async fn test_lance_v2_0_datasets_remain_operational_in_v0_11_0() {
         .unwrap();
     db.delete_edges(
         "Knows",
-        &DeletePredicate {
-            property: "src".to_string(),
-            op: DeleteOp::Eq,
-            value: "0".to_string(),
-        },
+        &DeletePredicate::compare("src".to_string(), DeleteOp::Eq, "0".to_string()),
     )
     .await
     .unwrap();
@@ -2291,11 +2287,7 @@ async fn test_delete_nodes_uses_lance_native_delete_path() {
 
     db.delete_nodes(
         "Person",
-        &DeletePredicate {
-            property: "name".to_string(),
-            op: DeleteOp::Eq,
-            value: "Bob".to_string(),
-        },
+        &DeletePredicate::compare("name".to_string(), DeleteOp::Eq, "Bob".to_string()),
     )
     .await
     .unwrap();
@@ -2332,11 +2324,7 @@ async fn test_compact_advances_dataset_versions_and_commits_manifest() {
     db.load(test_data_src()).await.unwrap();
     db.delete_edges(
         "Knows",
-        &DeletePredicate {
-            property: "src".to_string(),
-            op: DeleteOp::Eq,
-            value: "0".to_string(),
-        },
+        &DeletePredicate::compare("src".to_string(), DeleteOp::Eq, "0".to_string()),
     )
     .await
     .unwrap();
@@ -2381,11 +2369,7 @@ async fn test_cleanup_prunes_old_dataset_versions_but_keeps_manifest_visible_sta
     db.load(test_data_src()).await.unwrap();
     db.delete_edges(
         "Knows",
-        &DeletePredicate {
-            property: "src".to_string(),
-            op: DeleteOp::Eq,
-            value: "0".to_string(),
-        },
+        &DeletePredicate::compare("src".to_string(), DeleteOp::Eq, "0".to_string()),
     )
     .await
     .unwrap();
@@ -3073,11 +3057,7 @@ async fn test_delete_nodes_cascades_edges() {
     let result = db
         .delete_nodes(
             "Person",
-            &DeletePredicate {
-                property: "name".to_string(),
-                op: DeleteOp::Eq,
-                value: "Alice".to_string(),
-            },
+            &DeletePredicate::compare("name".to_string(), DeleteOp::Eq, "Alice".to_string()),
         )
         .await
         .unwrap();
@@ -3153,11 +3133,7 @@ async fn test_delete_edges_commits_through_mutation_pipeline() {
     let result = db
         .delete_edges(
             "Knows",
-            &DeletePredicate {
-                property: "src".to_string(),
-                op: DeleteOp::Eq,
-                value: alice_id.to_string(),
-            },
+            &DeletePredicate::compare("src".to_string(), DeleteOp::Eq, alice_id.to_string()),
         )
         .await
         .unwrap();
@@ -3207,11 +3183,7 @@ async fn test_delete_edges_uses_lance_native_delete_path() {
     let result = db
         .delete_edges(
             "Knows",
-            &DeletePredicate {
-                property: "dst".to_string(),
-                op: DeleteOp::Eq,
-                value: bob_id.to_string(),
-            },
+            &DeletePredicate::compare("dst".to_string(), DeleteOp::Eq, bob_id.to_string()),
         )
         .await
         .unwrap();

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -253,6 +253,7 @@ async fn run_db_mutation_test_with_params(
         nanograph::RunResult::Mutation(result) => MutationExecResult {
             affected_nodes: result.affected_nodes,
             affected_edges: result.affected_edges,
+            matched_nodes: result.matched_nodes,
         },
         nanograph::RunResult::Query(_) => panic!("expected mutation result"),
     }
@@ -1901,6 +1902,7 @@ query first_claim($name: String, $age: I32) {
     )
     .await;
     assert_eq!(result.affected_nodes, 1);
+    assert_eq!(result.matched_nodes, 1, "CAS won → matched_nodes is 1");
 
     // Same call again — Bob's age is no longer null, so the gate fails.
     let result2 = run_db_mutation_test_with_params(
@@ -1917,6 +1919,10 @@ query first_claim($name: String, $age: I32) {
     )
     .await;
     assert_eq!(result2.affected_nodes, 0);
+    assert_eq!(
+        result2.matched_nodes, 0,
+        "CAS lost → matched_nodes is 0 (the canonical agent signal)"
+    );
 
     // Alice's age was 30 (not null) from the start — the gate excludes her.
     let mut params_alice = ParamMap::new();

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1660,6 +1660,149 @@ query q() {
 }
 
 #[tokio::test]
+async fn test_update_with_conjunctive_where_block() {
+    // Verify the new `where { atom+ }` block AND's atoms conjunctively:
+    // only rows matching every atom should be touched.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    db.load(keyed_mutation_data()).await.unwrap();
+
+    // Alice is age 30; Bob is age 25. Update only the row whose name
+    // is "Alice" AND age is 30 — should affect exactly 1 row.
+    let mut params = ParamMap::new();
+    params.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Alice".to_string()),
+    );
+    params.insert(
+        "expected".to_string(),
+        nanograph::query::ast::Literal::Integer(30),
+    );
+    params.insert(
+        "next".to_string(),
+        nanograph::query::ast::Literal::Integer(31),
+    );
+    let result = run_db_mutation_test_with_params(
+        r#"
+query bump_age($name: String, $expected: I32, $next: I32) {
+    update Person set { age: $next } where {
+        name = $name
+        age = $expected
+    }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result.affected_nodes, 1);
+
+    // Calling the same mutation again should be a no-op now that age = 31,
+    // not 30 — the conjunctive predicate fails on the age atom.
+    let result2 = run_db_mutation_test_with_params(
+        r#"
+query bump_age($name: String, $expected: I32, $next: I32) {
+    update Person set { age: $next } where {
+        name = $name
+        age = $expected
+    }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result2.affected_nodes, 0);
+}
+
+#[tokio::test]
+async fn test_update_with_is_null_atom_in_where_block() {
+    // Race-safe claim pattern: only update rows where the gate field is null.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    // Seed with one row whose age is null and one whose age is set.
+    db.load(
+        r#"{"type":"Person","data":{"name":"Alice","age":30}}
+{"type":"Person","data":{"name":"Bob"}}
+"#,
+    )
+    .await
+    .unwrap();
+
+    // Update Bob (age is null) — should affect 1 row.
+    let mut params = ParamMap::new();
+    params.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Bob".to_string()),
+    );
+    params.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(42),
+    );
+    let result = run_db_mutation_test_with_params(
+        r#"
+query first_claim($name: String, $age: I32) {
+    update Person set { age: $age } where {
+        name = $name
+        age is null
+    }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result.affected_nodes, 1);
+
+    // Same call again — Bob's age is no longer null, so the gate fails.
+    let result2 = run_db_mutation_test_with_params(
+        r#"
+query first_claim($name: String, $age: I32) {
+    update Person set { age: $age } where {
+        name = $name
+        age is null
+    }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result2.affected_nodes, 0);
+
+    // Alice's age was 30 (not null) from the start — the gate excludes her.
+    let mut params_alice = ParamMap::new();
+    params_alice.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Alice".to_string()),
+    );
+    params_alice.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(99),
+    );
+    let result3 = run_db_mutation_test_with_params(
+        r#"
+query first_claim($name: String, $age: I32) {
+    update Person set { age: $age } where {
+        name = $name
+        age is null
+    }
+}
+"#,
+        &db,
+        &params_alice,
+    )
+    .await;
+    assert_eq!(result3.affected_nodes, 0);
+}
+
+#[tokio::test]
 async fn test_delete_edge_mutation_query() {
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("db");

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1762,7 +1762,10 @@ query ensure_knows($from: String, $to: String) {
     let r1 = run_db_mutation_test_with_params(put, &db, &params).await;
     assert_eq!(r1.affected_edges, 1);
     let r2 = run_db_mutation_test_with_params(put, &db, &params).await;
-    assert_eq!(r2.affected_edges, 1, "put reports the row touched each call");
+    assert_eq!(
+        r2.affected_edges, 1,
+        "put reports the row touched each call"
+    );
 
     // No duplicate edges after two calls.
     let rows = export_rows_for_db(&db).await;
@@ -1783,8 +1786,7 @@ node Tag {
     name: String
 }
 "#;
-    let parsed_schema =
-        nanograph::schema::parser::parse_schema(schema).expect("parse schema");
+    let parsed_schema = nanograph::schema::parser::parse_schema(schema).expect("parse schema");
     let catalog = build_catalog(&parsed_schema).expect("build catalog");
     let qf = parse_query(
         r#"

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1953,6 +1953,243 @@ query first_claim($name: String, $age: I32) {
 }
 
 #[tokio::test]
+async fn test_concurrent_cas_claim_exactly_one_wins() {
+    // The headline correctness claim: two simultaneous claims on the same row.
+    // The IS NULL gate combined with Lance's commit-level optimistic
+    // concurrency must guarantee exactly one matches — the other sees the
+    // gate fail at executor evaluation time (because the first claim's
+    // commit already flipped the column to non-null).
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    db.load(r#"{"type":"Person","data":{"name":"Bob"}}"#)
+        .await
+        .unwrap();
+
+    let claim = r#"
+query claim($name: String, $age: I32) {
+    update Person set { age: $age } where {
+        name = $name
+        age is null
+    }
+}
+"#;
+
+    let mut params_a = ParamMap::new();
+    params_a.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Bob".to_string()),
+    );
+    params_a.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(11),
+    );
+    let mut params_b = ParamMap::new();
+    params_b.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Bob".to_string()),
+    );
+    params_b.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(22),
+    );
+
+    let (r_a, r_b) = tokio::join!(
+        run_db_mutation_test_with_params(claim, &db, &params_a),
+        run_db_mutation_test_with_params(claim, &db, &params_b),
+    );
+
+    // Exactly one matched. The other's IS NULL gate failed because the first
+    // call's commit flipped the column to non-null before the second
+    // executor's mask construction read it.
+    let total_matched = r_a.matched_nodes + r_b.matched_nodes;
+    assert_eq!(
+        total_matched, 1,
+        "expected exactly one CAS winner, got a={} b={}",
+        r_a.matched_nodes, r_b.matched_nodes
+    );
+
+    // And the final row reflects exactly one winner — either 11 or 22, not both.
+    let rows = export_rows_for_db(&db).await;
+    let bob = rows
+        .iter()
+        .find(|row| {
+            row.get("type").and_then(serde_json::Value::as_str) == Some("Person")
+                && row["data"]["name"].as_str() == Some("Bob")
+        })
+        .unwrap();
+    let age = bob["data"]["age"].as_i64().unwrap();
+    assert!(age == 11 || age == 22, "unexpected final age {}", age);
+}
+
+#[tokio::test]
+async fn test_delete_with_conjunctive_where_block() {
+    // Conjunctive predicates work in delete too — only rows matching every
+    // atom should be removed.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    db.load(
+        r#"{"type":"Person","data":{"name":"Alice","age":30}}
+{"type":"Person","data":{"name":"Bob","age":30}}
+{"type":"Person","data":{"name":"Carol","age":40}}
+"#,
+    )
+    .await
+    .unwrap();
+
+    let mut params = ParamMap::new();
+    params.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Alice".to_string()),
+    );
+    params.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(30),
+    );
+    let result = run_db_mutation_test_with_params(
+        r#"
+query del($name: String, $age: I32) {
+    delete Person where {
+        name = $name
+        age = $age
+    }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result.affected_nodes, 1);
+    assert_eq!(result.matched_nodes, 1);
+
+    // Bob (matches age but not name) and Carol (matches neither) survive.
+    let rows = export_rows_for_db(&db).await;
+    let persons: Vec<_> = rows
+        .iter()
+        .filter(|row| row.get("type").and_then(serde_json::Value::as_str) == Some("Person"))
+        .collect();
+    assert_eq!(persons.len(), 2);
+    assert!(
+        persons.iter().any(|p| p["data"]["name"] == "Bob"),
+        "Bob should survive"
+    );
+    assert!(
+        persons.iter().any(|p| p["data"]["name"] == "Carol"),
+        "Carol should survive"
+    );
+}
+
+#[tokio::test]
+async fn test_is_not_null_atom_in_where_block() {
+    // Symmetric with is_null — only rows where the property IS set should match.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    db.load(
+        r#"{"type":"Person","data":{"name":"Alice","age":30}}
+{"type":"Person","data":{"name":"Bob"}}
+"#,
+    )
+    .await
+    .unwrap();
+
+    let result = run_db_mutation_test_with_params(
+        r#"
+query clear_ages() {
+    delete Person where { age is not null }
+}
+"#,
+        &db,
+        &ParamMap::new(),
+    )
+    .await;
+    // Alice (age set) deleted; Bob (age null) survives.
+    assert_eq!(result.affected_nodes, 1);
+    assert_eq!(result.matched_nodes, 1);
+
+    let rows = export_rows_for_db(&db).await;
+    let persons: Vec<_> = rows
+        .iter()
+        .filter(|row| row.get("type").and_then(serde_json::Value::as_str) == Some("Person"))
+        .collect();
+    assert_eq!(persons.len(), 1);
+    assert_eq!(persons[0]["data"]["name"], "Bob");
+}
+
+#[tokio::test]
+async fn test_typecheck_is_null_on_non_nullable_property_fails() {
+    let catalog = build_catalog(
+        &parse_schema(
+            r#"
+node Person {
+    name: String @key
+    age: I32
+}
+"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let qf = parse_query(
+        r#"
+query del() {
+    delete Person where {
+        name = "x"
+        age is null
+    }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query_decl(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("T11") && msg.contains("non-nullable") && msg.contains("age"),
+        "expected non-nullable IS NULL error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_typecheck_multi_atom_with_unknown_property_fails() {
+    let catalog = build_catalog(
+        &parse_schema(
+            r#"
+node Person {
+    name: String @key
+    age: I32?
+}
+"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let qf = parse_query(
+        r#"
+query bad() {
+    update Person set { age: 1 } where {
+        name = "x"
+        nonexistent = 42
+    }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query_decl(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("T11") && msg.contains("nonexistent"),
+        "expected unknown property error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn test_delete_edge_mutation_query() {
     let dir = tempfile::TempDir::new().unwrap();
     let db_path = dir.path().join("db");

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1660,6 +1660,148 @@ query q() {
 }
 
 #[tokio::test]
+async fn test_put_node_inserts_when_absent_and_updates_when_present() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    // Start empty — no Alice yet.
+    let mut params = ParamMap::new();
+    params.insert(
+        "name".to_string(),
+        nanograph::query::ast::Literal::String("Alice".to_string()),
+    );
+    params.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(30),
+    );
+    let result = run_db_mutation_test_with_params(
+        r#"
+query upsert_person($name: String, $age: I32) {
+    put Person { name: $name, age: $age }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result.affected_nodes, 1);
+
+    let rows = export_rows_for_db(&db).await;
+    let alice = rows
+        .iter()
+        .find(|row| {
+            row.get("type").and_then(serde_json::Value::as_str) == Some("Person")
+                && row["data"]["name"].as_str() == Some("Alice")
+        })
+        .unwrap();
+    assert_eq!(alice["data"]["age"].as_i64(), Some(30));
+
+    // Same put with a different age — should update, not duplicate.
+    params.insert(
+        "age".to_string(),
+        nanograph::query::ast::Literal::Integer(42),
+    );
+    let result2 = run_db_mutation_test_with_params(
+        r#"
+query upsert_person($name: String, $age: I32) {
+    put Person { name: $name, age: $age }
+}
+"#,
+        &db,
+        &params,
+    )
+    .await;
+    assert_eq!(result2.affected_nodes, 1);
+
+    let rows_after = export_rows_for_db(&db).await;
+    let alices: Vec<_> = rows_after
+        .iter()
+        .filter(|row| {
+            row.get("type").and_then(serde_json::Value::as_str) == Some("Person")
+                && row["data"]["name"].as_str() == Some("Alice")
+        })
+        .collect();
+    assert_eq!(alices.len(), 1, "put must not duplicate by @key");
+    assert_eq!(alices[0]["data"]["age"].as_i64(), Some(42));
+}
+
+#[tokio::test]
+async fn test_put_edge_is_idempotent() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(&db_path, keyed_mutation_schema())
+        .await
+        .unwrap();
+    db.load(
+        r#"{"type":"Person","data":{"name":"Alice","age":30}}
+{"type":"Person","data":{"name":"Bob","age":25}}
+"#,
+    )
+    .await
+    .unwrap();
+
+    let mut params = ParamMap::new();
+    params.insert(
+        "from".to_string(),
+        nanograph::query::ast::Literal::String("Alice".to_string()),
+    );
+    params.insert(
+        "to".to_string(),
+        nanograph::query::ast::Literal::String("Bob".to_string()),
+    );
+
+    let put = r#"
+query ensure_knows($from: String, $to: String) {
+    put Knows { from: $from, to: $to }
+}
+"#;
+
+    let r1 = run_db_mutation_test_with_params(put, &db, &params).await;
+    assert_eq!(r1.affected_edges, 1);
+    let r2 = run_db_mutation_test_with_params(put, &db, &params).await;
+    assert_eq!(r2.affected_edges, 1, "put reports the row touched each call");
+
+    // No duplicate edges after two calls.
+    let rows = export_rows_for_db(&db).await;
+    let knows: Vec<_> = rows
+        .iter()
+        .filter(|row| row.get("edge").and_then(serde_json::Value::as_str) == Some("Knows"))
+        .collect();
+    assert_eq!(knows.len(), 1, "put must not duplicate by (from, to)");
+}
+
+#[tokio::test]
+async fn test_put_node_without_key_property_errors_at_lint() {
+    use nanograph::build_catalog;
+    use nanograph::query::parser::parse_query;
+    use nanograph::query::typecheck::typecheck_query_decl;
+    let schema = r#"
+node Tag {
+    name: String
+}
+"#;
+    let parsed_schema =
+        nanograph::schema::parser::parse_schema(schema).expect("parse schema");
+    let catalog = build_catalog(&parsed_schema).expect("build catalog");
+    let qf = parse_query(
+        r#"
+query tag_it($name: String) {
+    put Tag { name: $name }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query_decl(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("T22") && msg.contains("@key"),
+        "expected T22 @key error, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn test_update_with_conjunctive_where_block() {
     // Verify the new `where { atom+ }` block AND's atoms conjunctively:
     // only rows matching every atom should be touched.

--- a/crates/nanograph/tests/write_amp_perf.rs
+++ b/crates/nanograph/tests/write_amp_perf.rs
@@ -364,11 +364,7 @@ async fn run_delete_scenario(rows: usize) -> ScenarioMetrics {
     let start = Instant::now();
     db.delete_edges(
         "Knows",
-        &DeletePredicate {
-            property: "src".to_string(),
-            op: DeleteOp::Lt,
-            value: cutoff.to_string(),
-        },
+        &DeletePredicate::compare("src".to_string(), DeleteOp::Lt, cutoff.to_string()),
     )
     .await
     .expect("delete mutation");

--- a/docs/user/queries.md
+++ b/docs/user/queries.md
@@ -7,6 +7,40 @@ slug: queries
 
 nanograph queries are defined in `.gq` files. The query language uses typed Datalog semantics with GraphQL-shaped syntax — named, parameterized queries validated against the schema at compile time.
 
+## Design philosophy: the agent toolbelt
+
+Each named query in a `.gq` file is a **tool**. The query language is the toolbelt. Workflows are sequences of tool calls — composed by the caller (typically an LLM agent), not by the query language itself.
+
+This is the deliberate distinguishing wager of nanograph versus Cypher / TypeQL / SQL: those languages let humans write complex multi-stage queries because a human is the user. Nanograph's user is an agent, which is much better at *selecting and chaining simple tools* than at *constructing complex queries*. The complexity profile is intentionally inverted.
+
+Concrete consequences for how you write `.gq` files:
+
+- **One query = one atomic operation = one tool call.** A query body holds one read pattern or one mutation. Multi-step workflows are sequences of named queries the agent calls in order. There are no transactional bundles, no `try { }` blocks, no `assert` stages, no `WITH` clauses.
+
+- **Mutations are single-row and idempotent where possible.** Prefer `put` (upsert by `@key`) over insert-then-update dances. Race-safety comes from `where { ... }` blocks with conjunctive filter clauses (e.g. `where { slug = $s; claimedBy is null }`) — there are no boolean operators, conjunction is structural, OR is unrepresentable by design. The result envelope (`matched_nodes`, `affected_nodes`, optional `rows`) tells the agent what happened.
+
+- **Reads are narrow.** If a "detail" view needs the assignee, the module, the recent events, and the dependency chain, that's **four narrow queries** the agent calls in parallel — not one wide query with optional blocks. Each narrow query is trivial to reason about, trivial to retry, and trivial for an LLM to compose.
+
+- **Use denormalized fields when they exist.** If `Issue.claimedBy: String?` already holds the assignee's slug, query that directly. Don't traverse the `Assigned` edge just to get the name — that introduces an inner-join footgun. The schema should make the common-case query a one-binding match.
+
+- **Name queries by what they do, not by what they touch.** `claim_issue`, `assign_issue`, `record_event` — verbs the agent can match to its intent. Avoid generated `update_issue_by_id` patterns; each query is a curated tool, not a CRUD endpoint.
+
+Example: an agent claiming an issue and recording it
+```
+// 1. CAS-safe atomic claim, observable outcome via matched_nodes
+nanograph run claim_issue --param slug=ng-001 --param agent=alice
+
+// 2. Idempotent edge insert
+nanograph run assign_issue --param agent=alice --param issue=ng-001
+
+// 3. Append the audit event (idempotent put by event slug)
+nanograph run record_event --param ev=ev-... --param issue=ng-001 \
+    --param actor=alice --param kind=claimed
+```
+Three tool calls. Each one is one atomic mutation. If the agent crashes between steps, retrying from the start is safe because each call is idempotent. The orchestration logic — "did the claim succeed? if so, write the edge; if so, emit the event" — lives in the agent, not in the query language.
+
+The full design rationale, principles, and rules for what to add (and not add) to the language live in `ql-canon.md` at the repo root.
+
 ## Query structure
 
 ```graphql

--- a/ql-canon.md
+++ b/ql-canon.md
@@ -1,0 +1,274 @@
+# nanograph query language canon
+
+This document defines what nanograph's query language is, the principles that keep it coherent, and the rules for evolving it. It is not a tutorial or a reference. It is a constitution for design decisions: when someone proposes a feature, this is the document we test it against.
+
+## Identity
+
+A nanograph query is a **typed function over a typed graph**. Its body is a single pattern. Its result is a flat table. Search and traversal are first-class operations within the pattern; mutations are pattern-gated row writes. Every query is a named, parameterized callable.
+
+The `.gq` file is the typed API surface of a database. For a human, each named query is a saved view. **For an LLM agent, each named query is a tool.** The terseness, the static checkability, the `@description` and `@instruction` metadata, the predictable flat result envelope — these all serve the agent-as-consumer case. Designing the language means designing what an agent can call.
+
+This identity is what we are protecting.
+
+We are not Cypher (no procedural pipelines, no path expressions, no graph-shaped output). We are not SQL (no general expression language, no CTEs, no subqueries, no `UNION`). We are not GraphQL (no nested input objects, no tree-shaped projections, no auto-generated CRUD). We are not TypeQL (no multi-stage pipelines, no in-language transactional bundles) or HelixQL (no multi-binding query bodies). We are closest to a typed Datalog with batteries — pattern matching, search predicates, and tabular projection — narrowed deliberately to a shape an agent can pick up and use as a tool.
+
+## Principles
+
+These are the load-bearing decisions. They take precedence over any feature.
+
+### P1. The pattern is the program
+
+A read query body is a single declarative pattern over the graph. There is no imperative control flow, no `WITH … RETURN` pipeline, no temporary results, no recursion (yet), no nested queries. The user describes a shape; the engine finds it. Compute happens elsewhere — in the schema (denormalized properties, materialized embeddings, indexes), in the projection (aggregations, search rankings), or in client code. Never in a procedural script inside the query.
+
+### P2. Types are the contract
+
+Every variable is typed against the catalog. Every property access is checked at lint time. Every parameter has a declared type. There is no `*`-style wildcard projection, no untyped property bag, no escape into raw JSON. The schema and the queries co-evolve; `nanograph lint` catches every structural error before runtime.
+
+### P3. One query = one named, atomic operation
+
+A query is a named function. Calling it is one logical operation. The unit of composition for users is the named query, not the statement. Today this means one read pattern XOR one mutation per body. When multi-statement transactions land, the named-query boundary remains the atomic unit — the body may grow, the unit will not.
+
+### P4. Flat in, flat out
+
+Inputs are scalars, vectors, and lists of scalars. Outputs are flat rows of typed columns. There are no nested input objects, no tree-shaped responses, no graph-shaped outputs. When a result needs structure, the answer is a second named query — not a richer projection language.
+
+### P5. Search is a first-class operator, not a parallel language
+
+`search`, `fuzzy`, `match_text`, `bm25`, `nearest`, `rrf` are functions in the same expression namespace as comparisons. There is no separate "search query" mode, no vector-DB sidecar dialect, no `MATCH AGAINST` clause. Hybrid search is composable function calls. Adding a new search modality is a new function, not a new clause.
+
+### P6. The grammar mirrors the planner
+
+The clause order `match → return → order? → limit?` is the executor's natural pipeline (scan → filter → join → project → sort → limit). Each clause has a place because it has work to do at that stage. New clauses must slot into this pipeline; reordering or non-linear composition is not on the table.
+
+### P7. Mutations are gated row writes
+
+A mutation specifies (a) what type to touch, (b) what fields to set, (c) which rows to touch via a predicate gate. Mutations do not traverse the graph, do not join, do not embed read patterns. The predicate is the gate. Writes are row-level: one mutation = one type = one gate = one write spec.
+
+### P8. The agent orchestrates; the QL is the toolbelt
+
+nanograph queries are designed to be called by an LLM agent as tools, not composed in-language as pipelines. Atomic operations stop at the query boundary. Multi-step workflows live in the agent's planning loop, not in the language. This is what differentiates nanograph from TypeDB, HelixDB, Cypher, and SQL — their target user is a human writing complex queries; ours is a machine selecting and chaining simple ones.
+
+Consequences that take precedence over feature requests:
+
+- Mutations are single-row, single-table, idempotent where possible. `put` (upsert) is the agent's primary mutation verb.
+- Race-safety is achieved with single-row CAS (compound `where` + `IS NULL`), not with locks, stage assertions, or transactional bundles.
+- Results are observable from the response envelope alone (`matched_nodes`, `affected_nodes`, optional `rows`) — no separate inspection round-trip required.
+- A workflow that needs three writes is three named queries the agent calls, not one query body with three stages.
+- A read that "needs context" is multiple narrow queries the agent composes, not one wide query with optional blocks.
+
+P8 is the principle most likely to be tested by future feature requests, because in-language orchestration is the dominant pattern in other graph DBs. Resist it: nanograph's distinguishing wager is that *the orchestration loop is the LLM's job*, not the engine's.
+
+## What we have today
+
+A reference catalog of patterns, organized by principle. New features should look like these.
+
+### Read pattern (P1, P6)
+
+```
+query open_high_priority()
+  @description("Open issues at priority 0 or 1.")
+{
+    match {
+        $i: Issue { status: "open" }
+        $i.priority < 2
+    }
+    return { $i.slug, $i.title, $i.priority }
+    order { $i.priority }
+    limit 20
+}
+```
+
+### Traversal (P1)
+
+```
+$a expert $m            // direction inferred from schema endpoints
+$b blocks{1,3} $i       // bounded transitive
+not { $b blocks $i }    // negation as antijoin
+```
+
+### Search expressions (P5)
+
+```
+search($n.body, $q)                              // FTS predicate (in match)
+nearest($n.embedding, $q) as score               // ranking (in order or return)
+rrf(nearest($n.embedding, $q),
+    bm25($n.body, $q)) as hybrid_score           // hybrid composition
+```
+
+### Mutations (P7)
+
+```
+insert Issue { slug: $s, title: $t, status: "open", ... }
+update Issue set { status: "closed" } where slug = $s
+delete Event where slug = $s
+```
+
+### Result envelope (P4)
+
+- Read: a flat table of typed columns. JSON modes carry `name`, `description`, `instruction` plus the row array.
+- Mutation: `{ affected_nodes, affected_edges }` (will gain `matched_nodes` and optional `returning` when CAS and RETURNING land).
+
+## Acknowledged tensions
+
+These are real ambiguities in the current language. The canon names them so future evolution resolves them deliberately, not by accident.
+
+### Implicit grouping for aggregations
+
+`count($x) as foo` alongside non-aggregate columns currently triggers undocumented grouping (and silently returns empty in some cases — see the codebase example's `module_backlog`). **Pick one**: either (a) implicit grouping by all non-aggregate projection columns is the documented contract and is fixed to actually work, or (b) explicit `group { $m.slug }` is added and implicit grouping becomes a lint error. Aggregation must not stay a footgun.
+
+### `nearest()` polymorphism
+
+`nearest()` appears in `expr` (so projection and ordering) but not as a top-level filter. It produces a similarity score. The dual role is fine; document it. **`nearest()` is a ranking function, not a predicate.** Conversely, the search predicates (`search`, `fuzzy`, `match_text`) are predicates, not rankings.
+
+### Mutation predicate strength
+
+Today: single property = value. The chosen extension is the **`where { ... }` block** — a brace-delimited list of newline-separated filter clauses, structurally symmetric with `match { ... }`. Conjunction is implicit in the block; there are no boolean operators (`AND`, `OR`, `NOT`) at the predicate level. This makes disjunction *unrepresentable in the grammar*, not just discouraged — the R3 first-of-family worry about boolean expression languages is eliminated at the syntax level. Single-predicate inline (`where slug = $s`) remains legal as sugar for `where { slug = $s }`. Pattern-as-gate (using a leading `match` clause as the CAS condition) is **rejected** — it requires multi-statement mutation bodies, which violates P3 and P8.
+
+### Update may match many rows
+
+The grammar permits `update Issue set {...} where status = "open"` which would update many rows. CLAUDE.md says "update requires @key, uses merge" but typecheck does not enforce it. **Resolve by**: explicitly support multi-row updates as a feature; document; rely on `matched_nodes` in the result envelope to surface the row count.
+
+### Edge endpoints are typed strings
+
+`from`/`to` on edges are `String` (the @key of the endpoint type). There is no foreign-key reference type. **This is intentional**: endpoints are content-addressable via the @key string. We will not introduce a typed reference.
+
+### Multi-statement query bodies
+
+A recurring temptation, especially when porting examples from TypeQL/HelixQL/Cypher: should a query body be allowed to contain a sequence of mutations and reads that commit atomically? **Resolved: no.** Per P3 and P8, one query = one named atomic operation = one tool call. Multi-step workflows are sequences of named queries the agent invokes. The single-statement form keeps each query simple to reason about, simple to retry, and simple for an LLM to select. See the anti-patterns table for the full rejection rationale.
+
+## Evolution rules
+
+Apply these in order to any feature proposal. If any returns "no," the feature in its proposed form is rejected.
+
+### R1. Which principle does it serve?
+
+For each P1–P7: does the feature make the principle more or less true? Reinforces all → proceed. Fights one → reframe or reject. The principles are not negotiable.
+
+### R2. Operator/function, or new clause?
+
+Operators and functions (`IS NULL`, `IN`, `OFFSET`, `DISTINCT`, `starts_with`) compose with existing grammar without changing the clause set. **Strongly prefer them.**
+
+New clauses (`group {}`, `optional {}`) change the pipeline shape. They are heavier; each needs to justify itself against P6.
+
+### R3. First-of-family check
+
+Some features look small but are gateways:
+
+- `+` arithmetic → expression language
+- `OR` between predicates → boolean expression precedence
+- `WITH x AS …` → procedural composition
+- `CASE WHEN` → conditionals
+- subqueries → nested compute
+- inline functions → general computation
+- a second statement in one query body → in-language orchestration (transactional bundles, cross-stage bindings, assertions, optional blocks)
+
+If the proposal is the first instance of one of these families, **reject the first instance**. The second and third are inevitable; either commit to the whole family (and accept the language becomes something else), or live without.
+
+### R4. Can it move out of the query?
+
+If the use case can be served by:
+
+- a schema change (new property, new index, denormalization)
+- a second named query the agent calls in sequence (per P8)
+- client-side or agent-loop post-processing
+
+…prefer that. The query language is for shape-finding and single-row mutations, not for orchestration or general computation.
+
+### R5. Does it preserve symmetry?
+
+The language has design symmetries that should not be broken without reason:
+
+- read body shape mirrors planner stages (scan → filter → join → project → sort → limit)
+- mutation has insert / update / delete / (upsert) — all single-type, all gated
+- search has predicate / rank / hybrid forms
+- every property type has scalar / nullable / list / vector forms
+
+A feature that breaks a symmetry must justify the asymmetry.
+
+## Backlog classification
+
+The gap list from the language review, sorted by canon compatibility.
+
+### Tier A — Reinforcing (ship without architectural worry)
+
+| Feature | Shape |
+|---|---|
+| `put` (upsert by @key) | Fourth mutation form, parallel to insert/update/delete. The agent's primary mutation verb. |
+| `where { }` block in mutations | Newline-separated conjunctive filters, mirrors `match { }`. Reuses existing filter grammar. Conjunction is structural — no boolean operators introduced. Enables single-row CAS. |
+| `IS NULL` / `IS NOT NULL` | Predicate operator. Pairs with `where { }` blocks for CAS gates. Also legal as a filter in `match`. |
+| `matched_nodes` in mutation result | Preserves flat envelope, gives agents the observable CAS signal. |
+| `RETURNING` on single-statement mutations | Preserves flat-out (P4). Mutation result envelope gains optional `rows`. |
+| `IN` with list-typed parameters | Operator + parameter type (closes the existing list-literal asymmetry). |
+| `OFFSET N` | Clause; slots cleanly into pipeline. |
+| `DISTINCT` | Projection modifier. |
+| Recursive traversal (`{1,*}`) | Extends bounded `{1,3}`. |
+| Time-travel / `as_of` | Query annotation, not body change. |
+| `starts_with` predicate | Second basic string predicate; **stop here**. |
+
+### Tier B — Reframing required (do the design work)
+
+| Feature | The reframe |
+|---|---|
+| Aggregation grouping | Resolve the tension above: either document implicit grouping precisely and fix it, or add an explicit `group { … }` clause. **No HAVING.** |
+| Path materialization | Introduce `path` as a typed projection-only value. No path expressions in match; the engine still does the traversal. |
+
+### Tier C — Risk Frankenstein (reject by default)
+
+| Feature | Why rejected |
+|---|---|
+| **Multi-statement query bodies** | Procedural composition lives in the agent (P8). One query = one named atomic operation (P3). |
+| **Cross-statement bindings** | Same. Bindings die at the query boundary. |
+| **`try { }` / `optional { }` blocks** | A wide query with optionals is the wrong shape — write narrower queries and let the agent compose. Adds nullable-column complexity to a flat-out language (P4). |
+| **`assert` / fail-loud stage guards** | The result envelope (`matched_nodes`) is the observability signal. Stage assertions presuppose multi-stage bodies. |
+| **Insert-from-pattern** (`insert Foo from match {…}`) | Conflates read and write; requires multi-statement semantics; agent can iterate match results client-side and call `put` per row. |
+| Cross-clause `OR` | Door to boolean expression precedence (R3). `IN` covers same-property OR. |
+| `HAVING` (post-aggregate filter) | Pulls SQL aggregation model behind it. Filter in client code or in a second query. |
+| Subqueries / `EXISTS` in match | Nesting door (R3). The pattern itself is the existence check. |
+| Cross-query bindings, prepared statements, session state | Procedural composition by the back door (P3, P8). |
+| String ops beyond `contains` and one prefix predicate | Slippery; once `LIKE` lands, regex follows. |
+| Math/string functions in expressions (`UPPER`, `+`, `||`) | First-of-family (R3); never. |
+| `CASE WHEN` / inline conditionals | First-of-family (R3); never. |
+| Object-shaped or graph-shaped projections | Breaks P4. Use a second named query. |
+| Auto-generated mutations per type (Hasura model) | Breaks the named-tool catalog model (P8). |
+| `*` projection / untyped result column | Breaks P2. |
+| Stored procedures / server-side scripting | Breaks P3 / P1 / P8. |
+
+## Anti-patterns and why
+
+| Anti-pattern | The objection |
+|---|---|
+| Multi-statement query bodies (sequence of stages) | Procedural composition lives in the agent (P8). Each query is one tool call; chained workflows are sequences of tool calls, not pipelines. |
+| Cross-statement variable bindings | Same — bindings die at the query boundary. |
+| `try { }` / `optional { }` blocks | Adds nullable-column complexity to a flat-out language (P4). Write narrower queries; the agent calls multiple. |
+| `assert` / fail-loud stage guards | The result envelope is the observability signal — `matched_nodes: 0` already tells the agent the CAS lost. Stage assertions presuppose multi-statement bodies. |
+| Insert-from-pattern (`insert Foo from match {…}`) | Conflates read and write; agent should iterate match results client-side and call `put` per row. |
+| Arithmetic / string functions in expressions | Once `LOWER()` exists, `SUBSTR`, `CONCAT`, `REGEXP_REPLACE` follow. The query language is not a programming language. |
+| Boolean operators (`AND`, `OR`, `NOT`, parens, precedence) in predicates | The `where { }` block uses conjunctive structure with no boolean operators — OR is *unrepresentable*, not just rejected. Adding boolean operators would require a parallel expression language. `IN` covers same-property OR. |
+| Subqueries returning scalars | Requires an expression language to consume them. |
+| `WITH` / CTEs | Procedural composition. The named-query model is our composition tool. |
+| `HAVING` | Imports the full SQL aggregation model. |
+| Object-shaped or graph-shaped result | The flat-table contract is what makes results trivially serializable, indexable, joinable in client code, and consumable by agents. |
+| Auto-generated mutations per type | Hasura ships 12 mutations per table; agents can't tell which to call. Named queries are intentional and discoverable. |
+| `*` projection / untyped result column | Breaks P2; lint can't catch downstream consumers. |
+| Stored procedures / server-side scripting | Procedural composition by the back door (P3, P8). |
+
+## The six-question checklist
+
+Before merging any language change:
+
+1. Which of P1–P7 does it reinforce? Which (if any) does it fight?
+2. Is it an operator/function (Tier A) or a new clause (Tier B)? If Tier B, what justifies the new pipeline stage?
+3. Is it the first instance of an anti-pattern family (R3)? If so, reject.
+4. Could the use case be served by a schema change, a second named query, or client code (R4)?
+5. Is there a parallel construct in the language this feature should be symmetric with (R5)?
+6. After this change, does someone reading a `.gq` file still see the same language?
+
+If all six come back clean, the feature is canon-compatible.
+
+## Changing the canon itself
+
+This document evolves more slowly than the language. A canon change is a design pivot, not a feature addition; treat it accordingly. Changes here require:
+
+1. A worked example showing why the existing canon fails on a real workload.
+2. The proposed revision in full (no patches; replace the whole section).
+3. A walk-through of which existing language features become inconsistent under the revision and how they will be reconciled.

--- a/ql-update.md
+++ b/ql-update.md
@@ -1,0 +1,484 @@
+# nanograph QL Update — agent-toolbelt mutations
+
+A design proposal for the next round of query-language changes. Companion to `ql-canon.md`.
+
+## Executive summary
+
+Add five small operator-level features to make nanograph's QL a complete agent toolbelt for single-row atomic mutations. The whole batch:
+
+1. `put` (upsert by `@key`) — fourth mutation form
+2. `where { ... }` block in mutations (conjunctive by structure, no boolean operators)
+3. `IS NULL` / `IS NOT NULL` predicate operator
+4. `matched_nodes` field in `MutationResult`
+5. `returning` clause on single-statement mutations
+
+Plus three read-side paper cuts: `OFFSET`, `IN` with list-typed parameters, `DISTINCT`. Plus a bug fix: aggregation grouping.
+
+**Total cost**: ~900 LOC across grammar, AST, IR, planner, executor, docs. 4–6 working days. Two PRs (plus an optional third for aggregation).
+
+**What this gives the agent**:
+- An idempotent "ensure this exists" verb (`put`).
+- A race-safe atomic-claim primitive in one query (compound `where` + `IS NULL`).
+- Observable outcomes via `matched_nodes` — the agent can tell from the response envelope whether its CAS won, the row was missing, or it was a no-op.
+- An optional `returning` clause so a mutation can hand back the new state without a follow-up read.
+- Bulk targeted reads (`IN`), pagination (`OFFSET`), and dedup (`DISTINCT`).
+
+**What this explicitly is not**: a pipeline architecture, transactional bundles, optional matches, or cross-statement bindings. Per `ql-canon.md` P8 ("the agent orchestrates; the QL is the toolbelt"), multi-step workflows live in the agent's planning loop, not in the query language.
+
+**Backward compatibility**: zero breakage. Every existing query parses and executes identically.
+
+## Why this shape (and not pipelines)
+
+An earlier draft of this document proposed a pipeline architecture — query bodies as sequences of `match → mutation+ → return?` stages with cross-stage bindings, `try { }` optional blocks, and `assert` guards. That proposal was rejected and the reasons are recorded in `ql-canon.md` P8 and in the Tier C anti-patterns table. Briefly:
+
+- Nanograph's user is an LLM agent. The agent's strength is *selecting and chaining simple tool calls*; its weakness is constructing complex multi-stage queries. The complexity profile is inverted from TypeDB/HelixDB/Cypher.
+- Embedded queries are sub-millisecond. Round-trip cost between calls is irrelevant compared to LLM token-generation latency.
+- Multi-statement query bodies are the *first instance* of an in-language orchestration family (CTEs, stored procedures, transactional bundles, scripting). The canon's R3 rejects first-instances of anti-pattern families.
+- Single-row mutations + observable results give the agent all the primitives it needs to orchestrate workflows itself.
+
+This proposal stays inside those guardrails.
+
+## The five mutation features
+
+### 1. `put` (upsert by `@key`)
+
+**Syntax**: identical to `insert`, new keyword.
+```
+put Issue {
+    slug: $s,
+    title: $t,
+    status: "open",
+    createdAt: now(),
+    updatedAt: now()
+}
+```
+
+**Semantics**:
+- The `@key` value (here, `slug: $s`) is the gate.
+- Row exists → update the named non-key properties on that row.
+- Row doesn't exist → insert with all named properties.
+- Always one row affected. `MutationResult { matched_nodes: 1, affected_nodes: 1 }`.
+
+**Edge form**:
+```
+put Assigned { from: $a, to: $i }                          // idempotent, no props
+put Expert   { from: $a, to: $m, confidence: "high" }      // updates confidence on conflict
+```
+The (from, to) pair is the natural key.
+
+**Typecheck (T22)**:
+- For node `put`: type must have `@key`; @key property must be in the assignments; all non-nullable non-key properties must be in the assignments (the insert path needs them).
+- For edge `put`: `from` and `to` required; non-nullable edge properties required.
+
+**Why this fits the agent toolbelt**: idempotent retries. Agent calls `put Issue {...}` and gets the same result whether the row existed or not. The agent's loop simplifies — no try/insert/catch-duplicate dance.
+
+### 2. `where { }` block in mutations (conjunctive by structure)
+
+**Syntax**: extend mutation `where` to accept a brace-delimited block of filter clauses, structurally symmetric with `match { ... }`. Single-predicate inline form remains legal as sugar.
+
+```
+// One predicate — current syntax still works
+update Issue set { status: "closed" } where slug = $s
+
+// Multiple predicates — new block form
+update Issue set { claimedBy: $a, status: "in_progress", updatedAt: now() }
+where {
+    slug = $s
+    claimedBy is null
+}
+
+// Range + key example
+delete Event where {
+    issueSlug = $s
+    at < $cutoff
+}
+```
+
+**Grammar diff**:
+```diff
+- mutation_predicate = { ident ~ comp_op ~ match_value }
++ mutation_predicate = { mutation_pred_block | mutation_pred_atom }
++ mutation_pred_block = { "{" ~ mutation_pred_atom+ ~ "}" }
++ mutation_pred_atom = {
++     ident ~ comp_op ~ match_value
++   | ident ~ "IS" ~ "NULL"
++   | ident ~ "IS" ~ "NOT" ~ "NULL"
++ }
+```
+
+**Semantics**: all atoms in the block must hold. Clauses inside the block are the same `filter` grammar already used inside `match`, just without the variable-prefix (single target type — `slug` not `$i.slug`).
+
+**Why this shape over an `AND` keyword**:
+- **No new keyword.** Conjunction is implicit in the block structure, exactly as in `match { ... }`.
+- **OR is unrepresentable at the grammar level**, not just rejected by convention. There's no operator to combine clauses, only clauses themselves. The R3 first-of-family worry about boolean expression languages is eliminated structurally.
+- **Symmetric with `match`.** Anyone who understands `match { ... }` understands `where { ... }`.
+- **Backward compatible**: `where slug = $s` parses identically; new block form is purely additive.
+
+**Why this fits the agent toolbelt**: race-safe single-row CAS in one query, observable outcome via `matched_nodes`.
+
+### 3. `IS NULL` / `IS NOT NULL` predicate operator
+
+Shipped together with #2. The same atom shape (`ident IS [NOT] NULL`) is also legal in read-side `filter` clauses inside `match`:
+```
+match {
+    $i: Issue
+    $i.claimedBy IS NULL
+}
+return { $i.slug, $i.title }
+```
+
+### 4. `matched_nodes` in `MutationResult`
+
+```rust
+pub struct MutationResult {
+    pub affected_nodes: usize,
+    pub affected_edges: usize,
+    pub matched_nodes: usize,           // NEW
+}
+```
+
+Disambiguates "predicate matched 0 rows" from "row exists but write didn't change anything." Required for CAS to be observable — without it, `affected_nodes: 0` is silent failure.
+
+JSON envelope:
+```json
+{
+  "matched_nodes": 0,
+  "affected_nodes": 0,
+  "affected_edges": 0
+}
+```
+
+Agent reads `matched_nodes == 0` → "my CAS lost or the row doesn't exist; decide next step."
+
+### 5. `returning` clause on single-statement mutations
+
+**Syntax**: optional clause after `where`.
+```
+update Issue set {
+    claimedBy: $a, status: "in_progress", updatedAt: now()
+} where {
+    slug = $s
+    claimedBy is null
+}
+returning { $i.slug, $i.status, $i.claimedBy, $i.updatedAt }
+```
+
+**Semantics**: post-mutation state of every matched-and-affected row, projected through the `returning` clause. Result envelope gains an optional `rows` field:
+```json
+{
+  "matched_nodes": 1,
+  "affected_nodes": 1,
+  "rows": [{"slug": "ng-001", "status": "in_progress", "claimedBy": "alice", "updatedAt": "..."}]
+}
+```
+
+**Variable binding**: the `returning` clause uses the same flat projection grammar as `return`. The bound variable is the type being mutated (here `$i` referring to the Issue rows touched). Convention: the implicit binding name is `$<lowercase first letter of type>` if not explicitly named; can be changed if there's a preference.
+
+**Why this fits**: saves one round-trip without violating single-statement atomicity. Stays inside one Lance commit.
+
+## The three read-side paper cuts
+
+### `OFFSET N`
+```
+order { $i.priority }
+limit 10
+offset 20
+```
+Pure pagination addition. Slots into the existing read pipeline as another tail stage.
+
+### `IN` with list-typed parameters
+```
+query bulk_inspect($slugs: [String]) {
+    match { $i: Issue; $i.slug IN $slugs }
+    return { $i.slug, $i.status }
+}
+```
+Two changes:
+- Parameter type system accepts `[String]`, `[I32]`, etc. (the list-literal grammar already exists; this closes the asymmetry).
+- `IN` predicate operator in filter expressions and (optionally) in mutation `where` atoms.
+
+### `DISTINCT`
+```
+return distinct { $f.country }
+```
+Projection modifier. Planner already has DataFusion `DISTINCT` support; just a syntax surface.
+
+## The aggregation bug fix
+
+Today `count($x) as foo` with non-aggregate columns silently returns 0 rows in some cases (see codebase example's `module_backlog`). Two options:
+
+- **Option A**: document and fix implicit grouping. Group keys = all non-aggregate columns in `return`. Make this actually work in the executor.
+- **Option B**: add an explicit `group { $m.slug }` clause between `return` and `order`. Implicit grouping becomes a lint error.
+
+**Recommended**: A first (smaller, no grammar change). If implicit semantics turn out to be subtly wrong, fall back to B.
+
+Either way, this is a separate PR — can land before, during, or after the rest.
+
+## Worked examples
+
+### Idempotent claim with CAS
+
+```
+query claim_issue($slug: String, $agent: String) {
+    update Issue set {
+        claimedBy: $agent,
+        status: "in_progress",
+        updatedAt: now()
+    } where {
+        slug = $slug
+        claimedBy is null
+    }
+    returning { $i.slug, $i.status, $i.claimedBy, $i.updatedAt }
+}
+```
+
+Agent calls. Three observable outcomes from one response envelope:
+- `matched_nodes: 1, affected_nodes: 1, rows: [{...}]` → won the claim, see new state.
+- `matched_nodes: 0, affected_nodes: 0, rows: []` → row missing or already claimed. Agent decides whether to retry, escalate, or give up.
+
+### Idempotent edge insertion
+
+```
+query assign_issue($agent: String, $issue: String) {
+    put Assigned { from: $agent, to: $issue }
+}
+```
+
+Calling twice is safe. Agent doesn't need to check whether the edge exists first.
+
+### Atomic state transition with gate
+
+```
+query close_issue($slug: String, $reason: String) {
+    update Issue set {
+        status: "closed",
+        closedAt: now(),
+        closedReason: $reason,
+        updatedAt: now()
+    } where {
+        slug = $slug
+        status != "closed"
+    }
+    returning { $i.slug, $i.status, $i.closedAt }
+}
+```
+
+Preserves the original `closedAt` if called twice on an already-closed issue (predicate excludes already-closed rows).
+
+### Bulk-targeted prune
+
+```
+query prune_old_events($since: DateTime, $issue: String) {
+    delete Event where {
+        issueSlug = $issue
+        at < $since
+    }
+}
+```
+
+Before the `where { }` block this required either deleting events one by one or a CLI-level workaround. Now: one query.
+
+## How the codebase example bugs get fixed
+
+The codebase example's headline lifecycle bugs (`detail`, `my`, `active`, `history` returning wrong results after a runtime claim) get fixed by **rewriting the queries**, not the language. The language additions above make the rewrite possible.
+
+### `claim_issue` — idempotent + race-safe
+
+Today's broken version:
+```
+update Issue set { claimedBy: $a, status: "in_progress", updatedAt: now() }
+where slug = $s
+```
+
+After:
+```
+update Issue set { claimedBy: $a, status: "in_progress", updatedAt: now() }
+where {
+    slug = $s
+    claimedBy is null
+}
+returning { $i.slug, $i.status, $i.claimedBy }
+```
+
+### `assign_issue`, `record_event` — separate idempotent calls
+
+```
+query assign_issue($a, $i) { put Assigned { from: $a, to: $i } }
+
+query record_event($ev, $i, $actor, $kind) {
+    put Event { slug: $ev, issueSlug: $i, actor: $actor,
+                kind: $kind, payload: "{}", at: now() }
+}
+
+query records_event_edge($ev, $i) { put Records { from: $ev, to: $i } }
+```
+
+Agent's claim workflow becomes four named tool calls:
+1. `claim_issue` — atomic CAS; if `matched_nodes: 0`, abort.
+2. `assign_issue` — idempotent edge.
+3. `record_event` — idempotent event.
+4. `records_event_edge` — idempotent audit-trail edge.
+
+If the agent crashes between any two, retrying from the start is safe (every call after #1 is idempotent). The audit log might be incomplete on crash — that's the trade-off captured by P8: nanograph isn't the right tool for workloads needing strict cross-mutation atomicity.
+
+### `issue_detail` — use the denormalized field, not the edge
+
+Today's broken version inner-joins on `Assigned` and returns empty for unassigned issues. The fix is querying-side:
+```
+query issue_detail($slug: String) {
+    match { $i: Issue { slug: $slug } }
+    return {
+        $i.slug, $i.title, $i.status, $i.priority,
+        $i.description, $i.acceptance, $i.design,
+        $i.claimedBy as assignee        // already denormalized on Issue
+    }
+}
+```
+
+For richer assignee data (Agent's name, capabilities), a separate narrow query:
+```
+query issue_assignee($slug: String) {
+    match {
+        $i: Issue { slug: $slug }
+        $a: Agent { slug: $i.claimedBy }   // requires future syntax support
+    }
+    return { $a.slug, $a.name, $a.kind, $a.capabilities }
+}
+```
+
+(Note: the property-equality binding `{ slug: $i.claimedBy }` already works today via match-value variable references. The agent calls `issue_detail` first to get `claimedBy`, then `issue_assignee` if needed.)
+
+Same pattern for `issue_module` — a narrow query the agent calls when it needs the module.
+
+## Open design questions
+
+Three small calls. My recommendation in each.
+
+### Q1. `null` literal in `prop_match` braces
+
+The `IS NULL` operator covers null-checks inside `where { }` blocks. Should we also allow `null` as a value inside binding braces?
+
+```
+match { $i: Issue { slug: $s, claimedBy: null } }
+```
+
+**Recommendation**: yes — small grammar add, makes "find unclaimed issues" a one-line match. Trivially symmetric with the `IS NULL` operator.
+
+### Q2. `returning` variable name convention
+
+```
+update Issue set {...} where slug = $s
+returning { $i.slug, $i.status }    // implicit binding name?
+```
+
+Options:
+- A) Implicit binding `$i` (lowercase first letter of the type name).
+- B) Explicit binding: `update Issue as $i set {...} where ... returning { $i.slug }`.
+- C) Always `$row`, `$it`, or some fixed name.
+
+**Recommendation**: A. Predictable, terse, matches what people would type anyway. Document the rule explicitly.
+
+### Q3. `IN` list-parameter type form
+
+Two ways to declare a list parameter:
+- A) `$slugs: [String]` — matches the existing list literal syntax.
+- B) `$slugs: List<String>` — more GraphQL-ish.
+
+**Recommendation**: A. The list-literal syntax already uses `[...]`; symmetric.
+
+## Implementation plan
+
+### Two reviewable PRs (plus an optional third)
+
+#### PR-1: agent-toolbelt mutations (~500 LOC, 2–3 days)
+
+- `put` keyword + `put_stmt` grammar rule + typecheck T22.
+- `mutation_predicate` extended to `where { }` block (brace-delimited list of `mutation_pred_atom` clauses, conjunctive by structure).
+- `IS NULL` / `IS NOT NULL` available as both a `mutation_pred_atom` and a `filter` clause in `match`.
+- `MutationResult.matched_nodes` added; populated in executor; serialized in JSON envelope.
+- Lint accepts `null` in `prop_match` (Q1).
+- ~10–15 new unit tests; one CAS race-condition integration test.
+
+After PR-1 ships: race-safe claims work end-to-end. `put` works. The headline codebase-example bug becomes fixable by rewriting `claim_issue`.
+
+#### PR-2: read-side polish (~400 LOC, 2–3 days)
+
+- `returning` clause on insert/update/delete/put (Q2 binding convention).
+- `OFFSET N` clause after `limit`.
+- `IN` predicate operator + list parameter types (`[String]`, `[I32]`, etc.) (Q3).
+- `DISTINCT` projection modifier.
+- Result envelope gains optional `rows` field.
+
+#### PR-3 (optional, separate): aggregation fix
+
+- Either fix implicit grouping or add explicit `group { }` clause.
+- Independent from the other PRs.
+
+### Calendar
+
+| Phase | Effort | Dependencies |
+|---|---|---|
+| PR-1 | 2–3 days | none |
+| PR-2 | 2–3 days | PR-1 (uses the new mutation grammar foundation) |
+| PR-3 | 1–2 days | independent |
+| **Total** | **4–6 days** | sequential or parallel |
+
+### Test plan
+
+- Unit tests for every new grammar rule.
+- Typecheck unit tests: `put` constraints; `where { }` block with mixed comp-ops and IS-NULL atoms; list parameter type validation.
+- CAS race integration test: two concurrent claims on the same issue; exactly one matches.
+- Idempotency test: call `put` 100 times with the same key; verify single row, deterministic state.
+- `returning` test: every mutation form, verify `rows` matches post-mutation state.
+- `IN` test: list param with various element types.
+- `OFFSET` test: pagination correctness with sort.
+- Backward compat: every existing example query lints clean and produces identical results.
+
+## Migration and backward compatibility
+
+- **No breaking changes.** Every existing query parses and executes identically.
+- **Result envelope extension**: `matched_nodes` field is additive; consumers that ignore unknown fields continue to work. `rows` is an optional new field, only present when `returning` is used.
+- **No CLI changes.** All new shapes work with existing `nanograph run`, `nanograph lint`, etc.
+- **No SDK changes.** FFI and TS SDK call into the same `lower → execute → json_output` path; the result envelope extension is additive.
+- **No storage format changes.**
+
+## Out of scope
+
+Per `ql-canon.md` P8 and the Tier C anti-patterns table, these are explicitly **not** being proposed:
+
+- Multi-statement query bodies (transactional bundles).
+- Cross-statement variable bindings.
+- `try { }` / `optional { }` blocks in `match`.
+- `assert` / fail-loud stage guards.
+- Insert-from-pattern (`insert Foo from match {…}`).
+- Pattern-as-gate for mutations (using a leading `match` as the CAS condition).
+
+If a future use case requires any of these, it triggers a canon review — not a feature addition.
+
+## Success criteria
+
+This work is done when:
+
+1. The codebase example's headline lifecycle is correct under the new model:
+   - `claim_issue` is race-safe (concurrent claims → exactly one wins; loser sees `matched_nodes: 0`).
+   - The lifecycle workflow is documented as a sequence of named-query tool calls in the codebase-example README.
+   - `issue_detail` returns correct results for assigned and unassigned issues without an inner-join footgun.
+2. `put` is idempotent under retry for both nodes and edges.
+3. `returning` saves a round-trip when the agent needs post-mutation state.
+4. `IN`, `OFFSET`, `DISTINCT` cover the read-side paper cuts identified in the language review.
+5. All existing tests in the workspace pass unchanged.
+6. `ql-canon.md` reflects the shipped state.
+7. `docs/user/queries.md` documents the new mutation forms and the agent-toolbelt design philosophy.
+
+## References
+
+- `ql-canon.md` — the language constitution this proposal is tested against, especially P3, P7, P8 and the Tier C anti-patterns table.
+- `docs/user/queries.md` — user-facing query reference.
+
+## Decision log
+
+To be appended as decisions are taken on the open questions.
+
+- **(open)** Q1: `null` literal in `prop_match` braces — recommended yes.
+- **(open)** Q2: `returning` implicit binding name — recommended `$<lowercase first letter>` of type.
+- **(open)** Q3: list parameter type syntax — recommended `[String]` matching list literals.

--- a/ql-update.md
+++ b/ql-update.md
@@ -477,8 +477,8 @@ This work is done when:
 
 ## Decision log
 
-To be appended as decisions are taken on the open questions.
-
-- **(open)** Q1: `null` literal in `prop_match` braces — recommended yes.
-- **(open)** Q2: `returning` implicit binding name — recommended `$<lowercase first letter>` of type.
-- **(open)** Q3: list parameter type syntax — recommended `[String]` matching list literals.
+- **2026-05 (shipped, PR-1)** Mutation predicate shape: chose **`where { atom+ }` block** over the `AND`-keyword conjunction. Conjunction is structural (no boolean operators); OR is unrepresentable at the grammar level. See `ql-canon.md` "Acknowledged tensions → Mutation predicate strength".
+- **2026-05 (shipped, PR-1)** PR-1 features landed: `put` (upsert), `where { }` block, `IS NULL` / `IS NOT NULL` in mutation predicates, `matched_nodes` on `MutationResult`.
+- **(deferred to PR-2)** Q1: `null` literal in `prop_match` braces and `IS NULL` in `match` filters — read-side ergonomics, not blocking the agent toolbelt. Requires reworking `IRFilter` to enum form; deferred to its own PR.
+- **(open, PR-2)** Q2: `returning` implicit binding name — recommended `$<lowercase first letter>` of type.
+- **(open, PR-2)** Q3: list parameter type syntax — recommended `[String]` matching list literals.


### PR DESCRIPTION
## Summary

PR-1 of the agent-toolbelt query-language work proposed in `ql-update.md`. Adds four small additive mutation features that together make race-safe single-row mutations expressible as one atomic tool call — the canonical agent workflow primitive.

The new features:

1. **`put TypeName { ... }`** — fourth mutation form. Upsert by `@key` for nodes, by `(from, to)` for edges. Idempotent under retry.
2. **`where { atom+ }` block** — extends mutation predicates from one atom to a conjunctive list. Structurally symmetric with `match { ... }`; no `AND` keyword introduced.
3. **`IS NULL` / `IS NOT NULL`** — predicate atoms legal inside `where { }` blocks.
4. **`matched_nodes`** field on `MutationResult` — observable CAS outcome. Agent reads `matched_nodes: 0` to detect a lost race.

## Why this shape

Per `ql-canon.md` principle P8 ("the agent orchestrates; the QL is the toolbelt"):
- Each query is one atomic tool call. Multi-statement bodies, optional matches, and assert stages are explicitly anti-patterns.
- Conjunction is **structural** (block of clauses), not operator-based — OR is unrepresentable at the grammar level. The R3 first-of-family worry about boolean expression languages is eliminated by construction.

See the long-form rationale in `ql-canon.md` Tier A and the design doc at `ql-update.md`.

## Worked example (the headline use case)

Today's canonical race-safe claim:

```
query claim_issue($slug: String, $agent: String) {
    update Issue set { claimedBy: $agent, status: "in_progress", updatedAt: now() }
    where {
        slug = $slug
        claimedBy is null
    }
}
```

End-to-end demonstration (real CLI):

```
$ nanograph run claim_issue --slug=ng-001 --agent=alice
  → matched_nodes: 1, affected_nodes: 1  (alice wins)
$ nanograph run claim_issue --slug=ng-001 --agent=bob
  → matched_nodes: 0, affected_nodes: 0  (bob sees CAS lost — was: silent overwrite)
$ nanograph run inspect --slug=ng-001
  → { slug: "ng-001", status: "in_progress", claimedBy: "alice" }
```

## Commit sequence

| Commit | What |
|---|---|
| `0bee0e1` | Design docs (`ql-canon.md`, `ql-update.md`, agent-toolbelt philosophy in `queries.md`) |
| `e4fcabc` | AST/parser plumbing for where-block (no semantics; typecheck still enforces legacy single-Compare) |
| `24540a7` | Conjunctive where-block + IS NULL atoms wired through typecheck, IR, planner, executor |
| `2d0e635` | `put` mutation (node and edge upsert) |
| `a54537c` | `matched_nodes` field on MutationResult |
| `b2dcdaf` | Docs decision log + rustfmt cleanup |

## Test plan

- [x] `cargo build -p nanograph -p nanograph-cli` clean
- [x] `cargo test --workspace` → 562 passed / 0 failed
- [x] `cargo fmt --all --check` clean
- [x] Five new integration tests covering: conjunctive predicate match correctness, `IS NULL` gate semantics, `put` insert path, `put` update path with no duplicate by @key, `put` edge idempotency by (from, to), T22 lint error when `put` targets a type without `@key`
- [x] Existing `IS NULL` CAS test extended with `matched_nodes` assertions to demonstrate the observable agent signal
- [x] Backward-compat regression: starwars / revops / codebase example query suites all lint clean (84 queries across them)
- [x] End-to-end CLI demo: race-safe claim, idempotent put, matched_nodes envelope reaches CLI JSON output

## Out of scope (deferred to PR-2)

Per `ql-update.md`:
- `returning` clause on single-statement mutations
- `OFFSET N`
- `IN` operator with list parameters
- `DISTINCT` projection modifier
- `null` literal in `prop_match` braces and `IS NULL` in match-side filter clauses (read-side ergonomics; requires reworking `IRFilter` to enum form)

Per `ql-canon.md` Tier C — explicitly rejected:
- Multi-statement query bodies
- Cross-statement bindings
- `try { }` / `optional { }` blocks
- `assert` stage guards
- Insert-from-pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)