### PR TITLE
perf: per-query embed cache + drop custom CrossJoinExec (CL-510, CL-511)

### DIFF
--- a/crates/nanograph/src/plan/planner.rs
+++ b/crates/nanograph/src/plan/planner.rs
@@ -1229,8 +1229,16 @@ async fn resolve_nearest_query_embeddings(
     }
 
     let client = EmbeddingClient::from_env()?;
+    let model = client.model().to_string();
+    let cache = runtime.query_embedding_cache();
     let mut resolved_vectors = AHashMap::<(String, usize), Vec<f32>>::new();
     for (text, dim) in requests {
+        // CL-510: hit the per-runtime cache first. Agents that issue the
+        // same `nearest($x, $q)` query repeatedly skip the network call.
+        if let Some(vector) = cache.get(&model, &text, dim) {
+            resolved_vectors.insert((text, dim), vector);
+            continue;
+        }
         let vector = client
             .embed_texts_with_role(&[text.clone()], dim, EmbedRole::Query)
             .await?
@@ -1239,6 +1247,7 @@ async fn resolve_nearest_query_embeddings(
             .ok_or_else(|| {
                 NanoError::Execution("embedding provider returned no vector".to_string())
             })?;
+        cache.insert(&model, text.clone(), dim, vector.clone());
         resolved_vectors.insert((text, dim), vector);
     }
 

--- a/crates/nanograph/src/plan/planner.rs
+++ b/crates/nanograph/src/plan/planner.rs
@@ -28,6 +28,7 @@ use datafusion_physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
     aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy},
     filter::FilterExec,
+    joins::CrossJoinExec,
     limit::GlobalLimitExec,
     projection::{ProjectionExec, ProjectionExpr},
     sorts::sort::SortExec,
@@ -2059,20 +2060,6 @@ fn build_physical_plan(
                     })
                     .collect::<Vec<_>>();
 
-                let output_schema = if let Some(ref plan) = current_plan {
-                    // Append to existing schema
-                    let mut fields: Vec<Field> = plan
-                        .schema()
-                        .fields()
-                        .iter()
-                        .map(|f| f.as_ref().clone())
-                        .collect();
-                    fields.extend(scan_fields.clone());
-                    Arc::new(Schema::new(fields))
-                } else {
-                    Arc::new(Schema::new(scan_fields.clone()))
-                };
-
                 let indexed_props = &node_schema.indexed_properties;
                 let mut pushdown_filters =
                     build_scan_pushdown_filters(variable, filters, params, Some(indexed_props));
@@ -2106,11 +2093,7 @@ fn build_physical_plan(
 
                 if let Some(prev) = current_plan {
                     // Cross join with previous plan (for multi-binding patterns)
-                    current_plan = Some(Arc::new(CrossJoinExec::new(
-                        prev,
-                        Arc::new(scan),
-                        output_schema,
-                    )));
+                    current_plan = Some(Arc::new(CrossJoinExec::new(prev, Arc::new(scan))));
                 } else {
                     current_plan = Some(Arc::new(scan));
                 }
@@ -2211,19 +2194,6 @@ fn build_physical_plan_with_input(
                     })
                     .collect::<Vec<_>>();
 
-                let output_schema = if let Some(ref plan) = current_plan {
-                    let mut fields: Vec<Field> = plan
-                        .schema()
-                        .fields()
-                        .iter()
-                        .map(|f| f.as_ref().clone())
-                        .collect();
-                    fields.extend(scan_fields.clone());
-                    Arc::new(Schema::new(fields))
-                } else {
-                    Arc::new(Schema::new(scan_fields.clone()))
-                };
-
                 let indexed_props = &node_schema.indexed_properties;
                 let mut pushdown_filters =
                     build_scan_pushdown_filters(variable, filters, params, Some(indexed_props));
@@ -2252,11 +2222,7 @@ fn build_physical_plan_with_input(
                 );
 
                 if let Some(prev) = current_plan {
-                    current_plan = Some(Arc::new(CrossJoinExec::new(
-                        prev,
-                        Arc::new(scan),
-                        output_schema,
-                    )));
+                    current_plan = Some(Arc::new(CrossJoinExec::new(prev, Arc::new(scan))));
                 } else {
                     current_plan = Some(Arc::new(scan));
                 }
@@ -4406,231 +4372,6 @@ fn literal_list_to_f32_vector(items: &[Literal]) -> Result<Vec<f32>> {
         }
     }
     Ok(out)
-}
-
-/// A simple cross-join exec for combining multiple NodeScans
-#[derive(Debug)]
-struct CrossJoinExec {
-    left: Arc<dyn ExecutionPlan>,
-    right: Arc<dyn ExecutionPlan>,
-    output_schema: SchemaRef,
-    properties: Arc<PlanProperties>,
-}
-
-impl CrossJoinExec {
-    fn new(
-        left: Arc<dyn ExecutionPlan>,
-        right: Arc<dyn ExecutionPlan>,
-        output_schema: SchemaRef,
-    ) -> Self {
-        let properties = Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(output_schema.clone()),
-            datafusion_physical_plan::Partitioning::UnknownPartitioning(1),
-            datafusion_physical_plan::execution_plan::EmissionType::Incremental,
-            datafusion_physical_plan::execution_plan::Boundedness::Bounded,
-        ));
-        Self {
-            left,
-            right,
-            output_schema,
-            properties,
-        }
-    }
-}
-
-impl datafusion_physical_plan::DisplayAs for CrossJoinExec {
-    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "CrossJoinExec")
-    }
-}
-
-impl ExecutionPlan for CrossJoinExec {
-    fn name(&self) -> &str {
-        "CrossJoinExec"
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn schema(&self) -> SchemaRef {
-        self.output_schema.clone()
-    }
-
-    fn properties(&self) -> &Arc<PlanProperties> {
-        &self.properties
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.left, &self.right]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(CrossJoinExec::new(
-            children[0].clone(),
-            children[1].clone(),
-            self.output_schema.clone(),
-        )))
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<datafusion_execution::TaskContext>,
-    ) -> DFResult<SendableRecordBatchStream> {
-        enum CrossJoinState {
-            Init {
-                left_stream: SendableRecordBatchStream,
-                right_stream: SendableRecordBatchStream,
-                schema: SchemaRef,
-            },
-            Running {
-                left_stream: SendableRecordBatchStream,
-                right_batches: Vec<RecordBatch>,
-                current_left: Option<RecordBatch>,
-                right_idx: usize,
-                schema: SchemaRef,
-            },
-        }
-
-        let left_stream = self.left.execute(partition, context.clone())?;
-        let right_stream = self.right.execute(partition, context)?;
-
-        let init = CrossJoinState::Init {
-            left_stream,
-            right_stream,
-            schema: self.output_schema.clone(),
-        };
-
-        let stream = futures::stream::try_unfold(init, |state| async move {
-            use futures::StreamExt;
-
-            let mut state = state;
-            loop {
-                match state {
-                    CrossJoinState::Init {
-                        left_stream,
-                        mut right_stream,
-                        schema,
-                    } => {
-                        let mut right_batches = Vec::new();
-                        while let Some(batch) = right_stream.next().await {
-                            right_batches.push(batch?);
-                        }
-
-                        if right_batches.is_empty() {
-                            return Ok(None);
-                        }
-
-                        state = CrossJoinState::Running {
-                            left_stream,
-                            right_batches,
-                            current_left: None,
-                            right_idx: 0,
-                            schema,
-                        };
-                    }
-                    CrossJoinState::Running {
-                        mut left_stream,
-                        right_batches,
-                        mut current_left,
-                        mut right_idx,
-                        schema,
-                    } => {
-                        if current_left.is_none() {
-                            let next_left = match left_stream.next().await {
-                                Some(batch) => batch?,
-                                None => return Ok(None),
-                            };
-                            current_left = Some(next_left);
-                            right_idx = 0;
-                        }
-
-                        let left_batch = current_left.as_ref().expect("left batch set");
-
-                        while right_idx < right_batches.len() {
-                            let right_batch = &right_batches[right_idx];
-                            right_idx += 1;
-                            let cross = cross_join_batches(left_batch, right_batch, &schema)?;
-                            if cross.num_rows() > 0 {
-                                let next_state = CrossJoinState::Running {
-                                    left_stream,
-                                    right_batches,
-                                    current_left,
-                                    right_idx,
-                                    schema,
-                                };
-                                return Ok(Some((cross, next_state)));
-                            }
-                        }
-
-                        state = CrossJoinState::Running {
-                            left_stream,
-                            right_batches,
-                            current_left: None,
-                            right_idx: 0,
-                            schema,
-                        };
-                    }
-                }
-            }
-        });
-
-        Ok(Box::pin(
-            datafusion_physical_plan::stream::RecordBatchStreamAdapter::new(
-                self.output_schema.clone(),
-                stream,
-            ),
-        ))
-    }
-}
-
-fn cross_join_batches(
-    left: &RecordBatch,
-    right: &RecordBatch,
-    schema: &SchemaRef,
-) -> DFResult<RecordBatch> {
-    let left_rows = left.num_rows();
-    let right_rows = right.num_rows();
-    let total = left_rows * right_rows;
-
-    if total == 0 {
-        return Ok(RecordBatch::new_empty(schema.clone()));
-    }
-
-    let mut columns: Vec<arrow_array::ArrayRef> = Vec::new();
-
-    // Replicate left columns
-    for col in left.columns() {
-        let mut indices = Vec::with_capacity(total);
-        for i in 0..left_rows {
-            for _ in 0..right_rows {
-                indices.push(i as u64);
-            }
-        }
-        let idx = arrow_array::UInt64Array::from(indices);
-        let taken = arrow_select::take::take(col.as_ref(), &idx, None)?;
-        columns.push(taken);
-    }
-
-    // Replicate right columns
-    for col in right.columns() {
-        let mut indices = Vec::with_capacity(total);
-        for _ in 0..left_rows {
-            for j in 0..right_rows {
-                indices.push(j as u64);
-            }
-        }
-        let idx = arrow_array::UInt64Array::from(indices);
-        let taken = arrow_select::take::take(col.as_ref(), &idx, None)?;
-        columns.push(taken);
-    }
-
-    RecordBatch::try_new(schema.clone(), columns)
-        .map_err(|e| datafusion_common::DataFusionError::ArrowError(Box::new(e), None))
 }
 
 /// Anti-join exec: returns rows from left where no matching rows exist in right

--- a/crates/nanograph/src/store/database.rs
+++ b/crates/nanograph/src/store/database.rs
@@ -559,6 +559,12 @@ impl Database {
         self.tempdir.is_some()
     }
 
+    /// Test-only accessor for the query-embedding cache size (CL-510).
+    #[doc(hidden)]
+    pub fn query_embedding_cache_size_for_tests(&self) -> usize {
+        self.current_runtime().query_embedding_cache().__test_len()
+    }
+
     pub(crate) async fn lock_writer(&self) -> DatabaseWriteGuard<'_> {
         DatabaseWriteGuard {
             _guard: self.writer.lock().await,

--- a/crates/nanograph/src/store/runtime.rs
+++ b/crates/nanograph/src/store/runtime.rs
@@ -82,6 +82,46 @@ impl TextSearchCache {
     }
 }
 
+/// CL-510: in-process cache of query-text embeddings, scoped to the
+/// `DatabaseRuntime` lifetime. Agents that issue the same `nearest($x, $q)`
+/// query repeatedly (e.g. `similar_issues("memory leak")` called 5×) hit
+/// the cache instead of round-tripping to LM Studio / OpenAI / Gemini.
+///
+/// Key: `(model_name, text, dim)` — model is included so switching providers
+/// (OPENAI_API_KEY vs LMSTUDIO_BASE_URL) yields fresh entries without manual
+/// invalidation. Dim is included so a schema change that bumps `Vector(N)`
+/// re-embeds rather than returning a stale vector.
+///
+/// Unbounded for v1: a typical query-text embedding is ~4 KB at 1024 dims,
+/// so 1000 unique queries = ~4 MB. Add LRU eviction if real workloads grow
+/// beyond that.
+#[derive(Debug, Default)]
+pub(crate) struct QueryEmbeddingCache {
+    entries: std::sync::Mutex<std::collections::HashMap<(String, String, usize), Vec<f32>>>,
+}
+
+impl QueryEmbeddingCache {
+    pub(crate) fn get(&self, model: &str, text: &str, dim: usize) -> Option<Vec<f32>> {
+        let guard = self.entries.lock().ok()?;
+        guard
+            .get(&(model.to_string(), text.to_string(), dim))
+            .cloned()
+    }
+
+    pub(crate) fn insert(&self, model: &str, text: String, dim: usize, vector: Vec<f32>) {
+        if let Ok(mut guard) = self.entries.lock() {
+            guard.insert((model.to_string(), text, dim), vector);
+        }
+    }
+
+    /// Test-only — counts entries. Always-available so cross-crate tests
+    /// (engine_integration) can call it without cfg(test) gymnastics.
+    #[doc(hidden)]
+    pub fn __test_len(&self) -> usize {
+        self.entries.lock().map(|g| g.len()).unwrap_or(0)
+    }
+}
+
 async fn load_native_text_scores(
     locator: &DatasetLocator,
     property: &str,
@@ -370,6 +410,7 @@ pub(crate) struct DatabaseRuntime {
     node_batch_cache: Arc<NodeBatchCache>,
     node_lookup_cache: Arc<NodeLookupCache>,
     text_search_cache: Arc<TextSearchCache>,
+    query_embedding_cache: Arc<QueryEmbeddingCache>,
 }
 
 impl DatabaseRuntime {
@@ -384,6 +425,7 @@ impl DatabaseRuntime {
             node_batch_cache: Arc::new(NodeBatchCache::default()),
             node_lookup_cache: Arc::new(NodeLookupCache::default()),
             text_search_cache: Arc::new(TextSearchCache::default()),
+            query_embedding_cache: Arc::new(QueryEmbeddingCache::default()),
         }
     }
 
@@ -479,6 +521,10 @@ impl DatabaseRuntime {
 
     pub(crate) fn edge_index_cache(&self) -> Arc<EdgeIndexCache> {
         self.edge_index_cache.clone()
+    }
+
+    pub(crate) fn query_embedding_cache(&self) -> Arc<QueryEmbeddingCache> {
+        self.query_embedding_cache.clone()
     }
 
     pub(crate) async fn native_text_scores(

--- a/crates/nanograph/tests/engine_integration.rs
+++ b/crates/nanograph/tests/engine_integration.rs
@@ -1729,6 +1729,91 @@ query upsert_person($name: String, $age: I32) {
 }
 
 #[tokio::test]
+async fn test_query_embedding_cache_skips_network_on_repeat() {
+    // CL-510: an agent that issues the same `nearest($x, $q)` query
+    // repeatedly should only embed `$q` once. We verify by running the
+    // same query 5× and asserting the per-runtime cache holds exactly
+    // one entry after.
+    let _guard = EMBED_ENV_LOCK.lock().await;
+    let prev_mock = std::env::var_os("NANOGRAPH_EMBEDDINGS_MOCK");
+    unsafe {
+        std::env::set_var("NANOGRAPH_EMBEDDINGS_MOCK", "1");
+    }
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("db");
+    let db = Database::init(
+        &db_path,
+        r#"
+node Doc {
+    slug: String @key
+    body: String
+    embedding: Vector(8) @embed(body) @index
+}
+"#,
+    )
+    .await
+    .unwrap();
+    db.load(
+        r#"{"type":"Doc","data":{"slug":"a","body":"alpha doc about graphs"}}
+{"type":"Doc","data":{"slug":"b","body":"beta doc about databases"}}
+{"type":"Doc","data":{"slug":"c","body":"gamma doc about queries"}}
+"#,
+    )
+    .await
+    .unwrap();
+
+    let query_src = r#"
+query similar($q: String) {
+    match { $d: Doc }
+    return { $d.slug, nearest($d.embedding, $q) as score }
+    order { nearest($d.embedding, $q) }
+    limit 3
+}
+"#;
+    let mut params = ParamMap::new();
+    params.insert(
+        "q".to_string(),
+        nanograph::query::ast::Literal::String("graphs and queries".to_string()),
+    );
+
+    // Cache starts empty.
+    assert_eq!(db.query_embedding_cache_size_for_tests(), 0);
+
+    // 5 calls with the same query text.
+    for _ in 0..5 {
+        let batches = run_db_query_test_with_params(query_src, &db, &params).await;
+        let slugs = extract_string_column(&batches, "slug");
+        assert_eq!(slugs.len(), 3, "expected 3 ranked docs");
+    }
+
+    // Exactly one cache entry — the (model, "graphs and queries", 8) key.
+    // Note: nearest() appears in both filter and return positions in this
+    // query (via the AHashSet dedup); the cache further dedupes across
+    // all 5 executions.
+    assert_eq!(
+        db.query_embedding_cache_size_for_tests(),
+        1,
+        "5 calls with same $q should produce 1 cache entry"
+    );
+
+    // A different query text should produce a second entry.
+    let mut params2 = ParamMap::new();
+    params2.insert(
+        "q".to_string(),
+        nanograph::query::ast::Literal::String("different search text".to_string()),
+    );
+    let _ = run_db_query_test_with_params(query_src, &db, &params2).await;
+    assert_eq!(db.query_embedding_cache_size_for_tests(), 2);
+
+    // Restore env.
+    match prev_mock {
+        Some(value) => unsafe { std::env::set_var("NANOGRAPH_EMBEDDINGS_MOCK", value) },
+        None => unsafe { std::env::remove_var("NANOGRAPH_EMBEDDINGS_MOCK") },
+    }
+}
+
+#[tokio::test]
 async fn test_query_cache_returns_consistent_results_across_repeated_calls() {
     // Regression for CL-508: the compiled-query cache must return identical
     // results on hit vs miss. We call the same query 50× — first call is a


### PR DESCRIPTION
## Summary

- **CL-510**: cache query-text embeddings per `DatabaseRuntime`. Agents that fire the same `nearest($x, $q)` repeatedly (e.g. `similar_issues("memory leak")` 5× during a triage loop) now skip the network round-trip after the first call. Key is `(model, text, dim)` so provider swaps and `Vector(N)` changes invalidate naturally.
- **CL-511**: drop ~220 LOC of custom `CrossJoinExec` (state machine + `cross_join_batches` helper) in favor of `datafusion_physical_plan::joins::CrossJoinExec`. The built-in computes left ⨯ right schema internally, so the precomputed `output_schema` we threaded through becomes dead code and is removed.

The custom `AntiJoinExec` stays for now — it runs `apply_ir_filters` against the inner pipeline before collecting join keys, so a clean swap to `HashJoinExec(LeftAnti)` needs an IR-to-PhysicalExpr converter we don't have yet. Tracked separately.

Net diff: **+149 / −262** across 4 files.

## Test plan

- [x] `cargo build -p nanograph` clean
- [x] `cargo test -p nanograph --lib` — 359 passed
- [x] `cargo test -p nanograph --test engine_integration` — 54 passed, including new `test_query_embedding_cache_skips_network_on_repeat` and the two-hop traversal tests that exercise the new cross-join path
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy -p nanograph --tests` — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)