### PR TITLE
Add nanograph-py: PyO3 Python binding (sibling to nanograph-ts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,6 +3114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +4024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,6 +4172,16 @@ version = "1.3.0"
 dependencies = [
  "arrow-ipc",
  "nanograph",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "nanograph-py"
+version = "1.3.0"
+dependencies = [
+ "nanograph",
+ "pyo3",
  "serde_json",
  "tokio",
 ]
@@ -4896,6 +4924,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5945,6 +6036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6364,6 +6461,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/nanograph-cli",
     "crates/nanograph-ts",
     "crates/nanograph-ffi",
+    "crates/nanograph-py",
 ]
 default-members = [
     "crates/nanograph",

--- a/crates/nanograph-py/Cargo.toml
+++ b/crates/nanograph-py/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nanograph-py"
+version = "1.3.0"
+edition = "2024"
+description = "NanoGraph Python SDK via PyO3 (spike)"
+license = "MIT"
+
+[lib]
+name = "nanograph_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+nanograph = { path = "../nanograph", version = "1.3.0" }
+pyo3 = { version = "0.23", features = ["extension-module"] }
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/nanograph-py/src/lib.rs
+++ b/crates/nanograph-py/src/lib.rs
@@ -1,0 +1,226 @@
+//! PyO3 binding for nanograph (the chosen "B" path).
+//!
+//! Mirrors the structure of `nanograph-ffi` (an owned tokio `Runtime` that
+//! `block_on`s the async core) but exposes a `#[pyclass]` instead of a C ABI.
+//!
+//! Crucially for the Hermes use case, every blocking core call runs inside
+//! `Python::allow_threads(...)`, so the GIL is released for the duration of
+//! the database work. That makes `sync_turn()`-style writes from a daemon
+//! thread genuinely non-blocking with respect to the agent's main loop —
+//! the requirement the Hermes MemoryProvider contract imposes.
+//!
+//! Methods return JSON strings; the Python wrapper json.loads them. A fully
+//! productionized binding would project to native Python objects and could
+//! expose true async via `pyo3-async-runtimes`, but the synchronous +
+//! allow_threads shape already satisfies the non-blocking contract.
+
+use std::sync::Mutex;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use tokio::runtime::Runtime;
+
+use nanograph::store::database::{Database, EmbedOptions, LoadMode};
+use nanograph::{JsonParamMode, find_named_query, json_params_to_param_map};
+
+fn err<E: std::fmt::Display>(e: E) -> PyErr {
+    PyRuntimeError::new_err(e.to_string())
+}
+
+#[pyclass]
+struct Db {
+    rt: Runtime,
+    db: Mutex<Option<Database>>,
+}
+
+impl Db {
+    fn database(&self) -> PyResult<Database> {
+        self.db
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("lock poisoned"))?
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| PyRuntimeError::new_err("database is closed"))
+    }
+}
+
+#[pymethods]
+impl Db {
+    #[staticmethod]
+    fn open_in_memory(py: Python<'_>, schema: &str) -> PyResult<Db> {
+        let rt = Runtime::new().map_err(err)?;
+        let db = py
+            .allow_threads(|| rt.block_on(Database::open_in_memory(schema)))
+            .map_err(err)?;
+        Ok(Db {
+            rt,
+            db: Mutex::new(Some(db)),
+        })
+    }
+
+    #[staticmethod]
+    fn init(py: Python<'_>, path: &str, schema: &str) -> PyResult<Db> {
+        let rt = Runtime::new().map_err(err)?;
+        let db = py
+            .allow_threads(|| rt.block_on(Database::init(std::path::Path::new(path), schema)))
+            .map_err(err)?;
+        Ok(Db {
+            rt,
+            db: Mutex::new(Some(db)),
+        })
+    }
+
+    #[staticmethod]
+    fn open(py: Python<'_>, path: &str) -> PyResult<Db> {
+        let rt = Runtime::new().map_err(err)?;
+        let db = py
+            .allow_threads(|| rt.block_on(Database::open(std::path::Path::new(path))))
+            .map_err(err)?;
+        Ok(Db {
+            rt,
+            db: Mutex::new(Some(db)),
+        })
+    }
+
+    fn load(&self, py: Python<'_>, data: &str, mode: &str) -> PyResult<()> {
+        let mode = match mode {
+            "overwrite" => LoadMode::Overwrite,
+            "append" => LoadMode::Append,
+            "merge" => LoadMode::Merge,
+            other => return Err(PyRuntimeError::new_err(format!("bad load mode: {other}"))),
+        };
+        let db = self.database()?;
+        py.allow_threads(|| self.rt.block_on(db.load_with_mode(data, mode)))
+            .map_err(err)
+    }
+
+    #[pyo3(signature = (query_source, query_name, params=None))]
+    fn run(
+        &self,
+        py: Python<'_>,
+        query_source: &str,
+        query_name: &str,
+        params: Option<&str>,
+    ) -> PyResult<String> {
+        let query = find_named_query(query_source, query_name).map_err(err)?;
+        let params_val: Option<serde_json::Value> = match params {
+            Some(s) if !s.trim().is_empty() => Some(serde_json::from_str(s).map_err(err)?),
+            _ => None,
+        };
+        let param_map =
+            json_params_to_param_map(params_val.as_ref(), &query.params, JsonParamMode::Standard)
+                .map_err(err)?;
+        let db = self.database()?;
+        // GIL released for the duration of query planning + execution.
+        let value = py
+            .allow_threads(|| -> Result<serde_json::Value, String> {
+                if query.mutation.is_some() {
+                    self.rt
+                        .block_on(db.run_query(&query, &param_map))
+                        .map(|r| r.to_sdk_json())
+                        .map_err(|e| e.to_string())
+                } else {
+                    let prepared = db.prepare_read_query(&query).map_err(|e| e.to_string())?;
+                    self.rt
+                        .block_on(prepared.execute(&param_map))
+                        .map(|r| r.to_sdk_json())
+                        .map_err(|e| e.to_string())
+                }
+            })
+            .map_err(PyRuntimeError::new_err)?;
+        serde_json::to_string(&value).map_err(err)
+    }
+
+    #[pyo3(signature = (options=None))]
+    fn changes(&self, py: Python<'_>, options: Option<&str>) -> PyResult<String> {
+        let (from, to) = match options {
+            Some(s) if !s.trim().is_empty() => {
+                let v: serde_json::Value = serde_json::from_str(s).map_err(err)?;
+                let from = v
+                    .get("since")
+                    .or_else(|| v.get("from"))
+                    .and_then(|x| x.as_u64())
+                    .unwrap_or(0);
+                (from, v.get("to").and_then(|x| x.as_u64()))
+            }
+            _ => (0, None),
+        };
+        let db = self.database()?;
+        let rows = py
+            .allow_threads(|| self.rt.block_on(db.changes(from, to)))
+            .map_err(err)?;
+        serde_json::to_string(&rows).map_err(err)
+    }
+
+    #[pyo3(signature = (options=None))]
+    fn embed(&self, py: Python<'_>, options: Option<&str>) -> PyResult<String> {
+        let mut opts = EmbedOptions::default();
+        if let Some(s) = options {
+            if !s.trim().is_empty() {
+                let v: serde_json::Value = serde_json::from_str(s).map_err(err)?;
+                if let Some(b) = v.get("onlyNull").and_then(|x| x.as_bool()) {
+                    opts.only_null = b;
+                }
+                if let Some(b) = v.get("reindex").and_then(|x| x.as_bool()) {
+                    opts.reindex = b;
+                }
+                if let Some(b) = v.get("dryRun").and_then(|x| x.as_bool()) {
+                    opts.dry_run = b;
+                }
+                if let Some(t) = v.get("typeName").and_then(|x| x.as_str()) {
+                    opts.type_name = Some(t.to_string());
+                }
+                if let Some(p) = v.get("property").and_then(|x| x.as_str()) {
+                    opts.property = Some(p.to_string());
+                }
+                if let Some(l) = v.get("limit").and_then(|x| x.as_u64()) {
+                    opts.limit = Some(l as usize);
+                }
+            }
+        }
+        let db = self.database()?;
+        let r = py
+            .allow_threads(|| self.rt.block_on(db.embed(opts)))
+            .map_err(err)?;
+        serde_json::to_string(&serde_json::json!({
+            "embeddingsGenerated": r.embeddings_generated,
+            "rowsSelected": r.rows_selected,
+            "propertiesSelected": r.properties_selected,
+            "reindexedTypes": r.reindexed_types,
+            "dryRun": r.dry_run,
+        }))
+        .map_err(err)
+    }
+
+    fn describe(&self) -> PyResult<String> {
+        let db = self.database()?;
+        let ir = &db.schema_ir;
+        let node_types: Vec<_> = ir
+            .node_types()
+            .map(|nt| serde_json::json!({ "name": nt.name }))
+            .collect();
+        let edge_types: Vec<_> = ir
+            .edge_types()
+            .map(|et| serde_json::json!({ "name": et.name }))
+            .collect();
+        serde_json::to_string(&serde_json::json!({
+            "nodeTypes": node_types,
+            "edgeTypes": edge_types,
+        }))
+        .map_err(err)
+    }
+
+    fn close(&self) -> PyResult<()> {
+        *self
+            .db
+            .lock()
+            .map_err(|_| PyRuntimeError::new_err("lock poisoned"))? = None;
+        Ok(())
+    }
+}
+
+#[pymodule]
+fn nanograph_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Db>()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds `crates/nanograph-py` — a PyO3 binding for nanograph, structurally a sibling to the existing `crates/nanograph-ts` (napi) and `crates/nanograph-ffi` (C ABI) crates.

The binding exposes a synchronous `Db` `#[pyclass]` mirroring the napi `JsDatabase` surface: `init`, `open`, `open_in_memory`, `load`, `run`, `embed`, `changes`, `describe`, `close`. It owns a tokio `Runtime` and `block_on`s the async core — the same pattern `nanograph-ffi` already uses — but every `block_on` runs inside `Python::allow_threads(...)`, so the GIL is released for the duration of database work. That property matters for host frameworks that perform background writes from daemon threads (e.g. agent memory providers): without it the host's main loop would stall on every write.

## API

```python
from nanograph_py import Db

db = Db.open_in_memory(schema_src)         # also: Db.init(path, schema), Db.open(path)
db.load(jsonl_text, "overwrite")            # "append" / "merge" too
rows_json = db.run(query_src, "my_query", '{"q": "..."}')
db.embed('{"onlyNull": true}')              # backfill
db.close()
```

Methods return JSON strings; callers `json.loads()` them (matches the napi binding's row shape). A future iteration could project to native Python objects and/or expose true async via `pyo3-async-runtimes`.

## Verification

Built locally with `maturin develop -m crates/nanograph-py/Cargo.toml` (Python 3.12, pyo3 0.23). Driven through a shared test suite that also drives `nanograph-ffi` via Python `ctypes` — both bindings produce identical results across open / load / full-text recall (`search()`) / graph traversal / mutation insert / CDC ledger (`changes()`) / schema introspect. Latency is a wash (~0.2 ms p50 recall on a small corpus).

A concurrency test (4 threads × N recall calls vs 1 thread × N) shows ~1.5× throughput, confirming the GIL is in fact released during query execution.

End-to-end usage: this binding underlies a Hermes (NousResearch agent) memory provider plugin built against the real `MemoryProvider` ABC; with nanograph pointed at a local OpenAI-compatible embedding endpoint (LM Studio / omlx) via `LMSTUDIO_BASE_URL` + `NANOGRAPH_EMBED_MODEL`, semantic `nearest()` recall correctly ranks zero-lexical-overlap paraphrases on a Qwen3-Embedding-0.6B model.

## Notes

- Workspace `Cargo.toml` adds `crates/nanograph-py` to `[workspace] members`; `Cargo.lock` updates pull in pyo3 and friends.
- `[lib] name = "nanograph_py"`, `crate-type = ["cdylib"]` — same shape as `nanograph-ts`.
- Marked as a starting point; happy to iterate on naming, async story, return-type projection, or anything else on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
